### PR TITLE
issue-46: Fixed default formatting of readOnly form field

### DIFF
--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
@@ -7,6 +7,7 @@
     [label]="label"
     [value]="value"
     [textAlign]="textAlign"
+    [formatNumber]="formatNumber"
     [decimalPlaces]="decimalPlaces"
     [roundDisplayValue]="roundValue"
     [autofillDecimals]="autofillDecimals"

--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
@@ -1,4 +1,14 @@
-import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 
 /**
  * Wraps a mat-form-field to replace it by a readOnly representation if necessary
@@ -28,10 +38,11 @@ export class ReadOnlyFormFieldWrapperComponent implements OnInit, AfterViewInit,
    */
   label: string;
 
-  @ViewChild('contentWrapper', { static: false })
+  @ViewChild('contentWrapper', {static: false})
   originalContent: ElementRef;
 
   @Input('textAlign') textAlign: 'right' | 'left' = 'left';
+  @Input('formatNumber') formatNumber = false;
   @Input('decimalPlaces') decimalPlaces = 2;
   @Input('roundDisplayValue') roundValue = false;
   @Input('autofillDecimals') autofillDecimals = false;

--- a/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
@@ -28,6 +28,7 @@ export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
   @Input('value') value: any;
   @Input('label') label: string;
   @Input('textAlign') textAlign: 'right' | 'left' = 'left';
+  @Input('formatNumber') formatNumber = false;
   @Input('decimalPlaces') decimalPlaces = 2;
   @Input('roundDisplayValue') roundValue = false;
   @Input('autofillDecimals') autofillDecimals = false;
@@ -45,7 +46,7 @@ export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
   ngOnChanges(_: SimpleChanges): void {
     if (!NumberFormatService.valueIsSet(this.value)) {
       this.value = '-';
-    } else if (typeof this.value === 'number') {
+    } else if (this.formatNumber && typeof this.value === 'number') {
       this.value = this.numberFormatService.format(this.value, {
         decimalPlaces: this.decimalPlaces,
         finalFormatting: true,

--- a/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.html
+++ b/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.html
@@ -1,11 +1,28 @@
-<button mat-icon-button (click)="demoIdData = null" matTooltip="Clear value" type="button" style="margin-bottom: 1em; margin-right: 1em;">
+<button mat-icon-button (click)="demoIdData = null" matTooltip="Clear value" type="button"
+        style="margin-bottom: 1em; margin-right: 1em;">
   <mat-icon>delete</mat-icon>
 </button>
-<mat-checkbox [checked]="textIsEditable" (change)="textIsEditable = !textIsEditable">Text editable </mat-checkbox>
-<br />
+<mat-checkbox [checked]="textIsEditable" (change)="textIsEditable = !textIsEditable">Text editable</mat-checkbox>
+<br/>
 <mad-readonly-form-field-wrapper [readonly]="!textIsEditable" [value]="demoIdData">
   <mat-form-field class="form-group">
     <mat-label>First Name</mat-label>
-    <input [(ngModel)]="demoIdData" autocomplete="off" class="form-control" id="namex" matInput name="id" />
+    <input [(ngModel)]="demoIdData" autocomplete="off" class="form-control" id="namex" matInput name="id"/>
+  </mat-form-field>
+</mad-readonly-form-field-wrapper>
+<br/>
+<mad-readonly-form-field-wrapper [readonly]="!textIsEditable" [value]="demoIdNumber" [formatNumber]="false">
+  <mat-form-field class="form-group">
+    <mat-label>A long number</mat-label>
+    <input [(ngModel)]="demoIdNumber" autocomplete="off" class="form-control" id="numberx" matInput name="id"
+           type="number"/>
+  </mat-form-field>
+</mad-readonly-form-field-wrapper>
+<br/>
+<mad-readonly-form-field-wrapper [readonly]="!textIsEditable" [value]="demoIdNumber" [formatNumber]="true">
+  <mat-form-field class="form-group">
+    <mat-label>A long number, formatted</mat-label>
+    <input [(ngModel)]="demoIdNumber" autocomplete="off" class="form-control" id="numbery" matInput name="id"
+           type="number"/>
   </mat-form-field>
 </mad-readonly-form-field-wrapper>

--- a/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.ts
+++ b/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-read-only-field-wrapper',
@@ -7,5 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ReadOnlyFieldWrapperComponent {
   demoIdData = 'John Doe';
+  demoIdNumber = 12345678;
   textIsEditable = false;
 }

--- a/src/app/example-components/read-only-field/read-only-field.component.html
+++ b/src/app/example-components/read-only-field/read-only-field.component.html
@@ -1,6 +1,8 @@
 <mad-readonly-form-field [value]="'Jennifer Doe'" [label]="'Last changed by'"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="'2019-08-09' | date" [label]="'Last changed at'"></mad-readonly-form-field>
 <mad-readonly-form-field [label]="'Approved by'"></mad-readonly-form-field>
+<mad-readonly-form-field [value]="123456" [label]="'Long number, not formatted (default)'"></mad-readonly-form-field>
+<mad-readonly-form-field [value]="123456" [label]="'Long number, formatted as number'" [formatNumber]="true"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="zeroValue" [label]="'Zero value'"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="nullValue" [label]="'Null value'"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="undefinedValue" [label]="'Undefined value'"></mad-readonly-form-field>


### PR DESCRIPTION
### Description

Add an additional @input to explicitly enable number conversion, eg was added:

`@Input('formatNumber') formatNumber = false;`

Added in both mad-readonly-form-field and mad-readonly-form-field-wrapper

closes #46 