### PR TITLE
- Implement "shrinkIfEmpty" functionality for read-only-field and rea…

### DIFF
--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
@@ -16,6 +16,7 @@
     [errorMessage]="errorMessage"
     [multiline]="multiline"
     [rows]="rows"
+    [shrinkIfEmpty]="shrinkIfEmpty"
   >
   </mad-readonly-form-field>
 </ng-container>

--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
@@ -51,6 +51,14 @@ export class ReadOnlyFormFieldWrapperComponent implements OnInit, AfterViewInit,
    */
   @Input() rows = 3;
 
+  /**
+   * If shrinkIfEmpty is set to "false", nothing changes
+   * If set to "true" and multiline is also "true", the textarea will
+   * shrink to one row, if value is empty/null/undefined.
+   * Otherwise, the defined rows-value will be used
+   */
+  @Input() shrinkIfEmpty: boolean = false;
+
   constructor(private changeDetector: ChangeDetectorRef) {}
 
   ngOnInit(): void {

--- a/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
@@ -9,7 +9,6 @@ import {
   AfterViewChecked,
   ViewChild,
 } from '@angular/core';
-import { FormControl, FormGroupDirective, NgForm } from '@angular/forms';
 import { ErrorStateMatcher } from '@angular/material/core';
 import { NumberFormatService } from '../../numeric-field/number-format.service';
 
@@ -37,6 +36,13 @@ export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
   @Input('errorMessage') errorMessage: string | null = null;
   @Input() multiline = false;
   @Input() rows = 3;
+  /*
+   * If shrinkIfEmpty is set to "false", nothing changes
+   * If set to "true" and multiline is also "true", the textarea will
+   * shrink to one row, if value is empty/null/undefined.
+   * Otherwise, the defined rows-value will be used
+   */
+  @Input() shrinkIfEmpty: boolean = false;
   @ViewChild('inputEl') inputEl: ElementRef;
   errorMatcher: ErrorStateMatcher = {
     isErrorState: () => !!this.errorMessage,
@@ -50,6 +56,9 @@ export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
   ngOnChanges(_: SimpleChanges): void {
     if (!NumberFormatService.valueIsSet(this.value)) {
       this.value = '-';
+      if (this.shrinkIfEmpty) {
+        this.rows = 1;
+      }
     } else if (this.formatNumber && typeof this.value === 'number') {
       this.value = this.numberFormatService.format(this.value, {
         decimalPlaces: this.decimalPlaces,

--- a/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.html
+++ b/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.html
@@ -33,3 +33,9 @@
     <textarea [(ngModel)]="demoText" class="form-control" id="text" matInput name="text" matInput></textarea>
   </mat-form-field>
 </mad-readonly-form-field-wrapper>
+<mad-readonly-form-field-wrapper [readonly]="!textIsEditable" [multiline]="true" [value]="shrinkDemoText" [rows]="4" [shrinkIfEmpty]="true">
+  <mat-form-field class="form-group">
+    <mat-label>This text will shrink, if empty</mat-label>
+    <textarea [(ngModel)]="shrinkDemoText" class="form-control" id="shrinkDemoText" matInput name="shrinkDemoText" matInput></textarea>
+  </mat-form-field>
+</mad-readonly-form-field-wrapper>

--- a/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.ts
+++ b/src/app/example-components/read-only-field-wrapper/read-only-field-wrapper.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-read-only-field-wrapper',
@@ -12,4 +12,9 @@ export class ReadOnlyFieldWrapperComponent {
   demoText =
     'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore \n' +
     'et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. ';
+  shrinkDemoText =
+    '1.)\tThis text is defined to have 4 rows\n' +
+    '2.)\tdelete the text and it will shrink to one row\n' +
+    '3.)\tit would also shrink,\n' +
+    '4.)\tif value was undefined or null';
 }

--- a/src/app/example-components/read-only-field/read-only-field.component.html
+++ b/src/app/example-components/read-only-field/read-only-field.component.html
@@ -8,5 +8,6 @@
 <mad-readonly-form-field [value]="undefinedValue" [label]="'Undefined value'"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="" label="First name" errorMessage="Please enter a value for first name"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="demoText" [multiline]="true" label="Text with multiple lines"></mad-readonly-form-field>
+<mad-readonly-form-field [value]="nullValue" [multiline]="true" [rows]="4" [shrinkIfEmpty]="true" label="This text is defined to have 4 lines, but is shrank to one line, because it's empty"></mad-readonly-form-field>
 
 


### PR DESCRIPTION
…d-only-field-wrapper

- Update examples

### Description

Implement an option for readonly-form-field and readonly-form-field-wrapper to shrink to one row, if multipline is enabled and the value is empty, null or undefined

### Which Component is affected or generated?

readonly-form-field, readonly-form-field-wrapper and the corresponding examples
