### PR TITLE
Fixed resetting inputs to empty value that use the madNumericField directive (#85)

### DIFF
--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
@@ -61,7 +61,9 @@ export class NumericFieldDirective implements OnInit, OnDestroy, AfterViewChecke
   set numericValue(value: number) {
     if (this._numericValue !== value && !(isNaN(this._numericValue) && (isNaN(value) || value === null))) {
       this.originalValue = value;
-      this._numericValue = this.roundOrTruncate(value);
+      // Don't roundOrTruncate if value was set to empty otherwise input value will be set to 0 instead of empty
+      // which happens when an input is being reset
+      this._numericValue = value === null || value === undefined ? value : this.roundOrTruncate(value); // eslint-disable-line
       this.handleInputChanged();
     }
   }


### PR DESCRIPTION
### Description

Fixes the issue with the resetting of an input which value is initially not set. See issue #85 for the demo (https://stackblitz.com/edit/material-addons-numeric-field?file=src/app/app.component.ts)

### Which Component is affected or generated?

madNumericField directive
