### PR TITLE
hide delete button if minItems reached instead of disabling it, extracted base functionality of quick list, implemented quick list compact (#83 & #84)

### DIFF
--- a/projects/material-addons/src/lib/quick-list/base-quick-list.component.ts
+++ b/projects/material-addons/src/lib/quick-list/base-quick-list.component.ts
@@ -1,0 +1,106 @@
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ContentChild,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  QueryList,
+  TemplateRef,
+  ViewChildren,
+} from '@angular/core';
+
+export interface QuickListItem {
+  id: string;
+}
+
+@Component({
+  selector: 'mad-base-quick-list',
+  template: '',
+  styleUrls: [],
+})
+export class BaseQuickListComponent<T> implements OnInit, AfterViewInit {
+  @Input() allItems = [] as T[];
+  @Input() addLabel = 'NOT SET';
+  @Input() addPossible = true;
+  @Input() blankItem = {} as any;
+  @Input() readonly: boolean;
+  @Input() maxItems: number;
+  @Input() minItems: number;
+
+  @Output() added = new EventEmitter<T>();
+  @Output() removed = new EventEmitter<T>();
+  @ContentChild(TemplateRef) itemTemplate: TemplateRef<any>;
+  @ViewChildren('row') itemRows: QueryList<ElementRef>;
+
+  rowCountFocus: number;
+  addEventFunction: Function;
+
+  constructor(public changeDetectorRef: ChangeDetectorRef) { }
+
+  ngOnInit(): void {
+    this.addEventFunction = this.addItem.bind(this);
+    if (this.minItems) {
+      for (let n = this.allItems.length; n < this.minItems; n++) {
+        this.interalAddItem();
+      }
+    }
+  }
+
+  ngAfterViewInit(): void {
+    setTimeout(() => this.setFocusOnAdd(), 1);
+  }
+
+  addItem(): void {
+    const newItem = this.interalAddItem();
+    if (!!newItem) {
+      this.added.emit(newItem);
+    }
+  }
+
+  removeItem(item: T): void {
+    if (this.isDeleteAllowed()) {
+      this.allItems.splice(this.allItems.indexOf(item), 1);
+      this.removed.emit(item);
+    }
+  }
+
+  setFocusOnAdd(): void {
+    this.rowCountFocus = this.itemRows.length;
+    this.itemRows.changes.subscribe((els: QueryList<ElementRef>) => {
+      if (els.length > this.rowCountFocus && !!els.last) {
+        const firstFocusable = els.last.nativeElement.querySelector("button, a, input, select, textarea, [tabindex]:not([tabindex='-1'])");
+        if (firstFocusable) {
+          firstFocusable.focus();
+        }
+      }
+      this.rowCountFocus = els.length;
+    });
+  }
+
+  isAddAllowed(): boolean {
+    return this.addPossible && (!this.maxItems || this.allItems.length < this.maxItems);
+  }
+
+  isDeleteAllowed(): boolean {
+    return !this.minItems || this.allItems.length > this.minItems;
+  }
+
+  private interalAddItem(): T {
+    if (this.isAddAllowed()) {
+      const newItem = { ...this.blankItem };
+      // creates ids in the form of "n5kdz1pljl8"
+      newItem.id = Math.random()
+        .toString(36)
+        .substring(2);
+      this.allItems.push(newItem);
+      this.changeDetectorRef.detectChanges();
+      return newItem;
+    }
+    return null;
+  }
+
+}

--- a/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.html
+++ b/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.html
@@ -1,0 +1,19 @@
+<h3>
+    <ng-content select="label"></ng-content>
+</h3>
+<ng-container *ngFor="let item of allItems; let isLast = last;">
+    <div class="flex-container" *ngIf="itemTemplate" #row>
+        <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
+        <mad-icon-button *ngIf="!readonly && isDeleteAllowed()" (click)="removeItem(item)">
+            <mat-icon>delete</mat-icon>
+        </mad-icon-button>
+        <mad-icon-button *ngIf="!readonly && isLast" [disabled]="!isAddAllowed()" (click)="addItem()">
+            <mat-icon>add_circle_outline</mat-icon>
+        </mad-icon-button>
+    </div>
+</ng-container>
+<mad-link-button *ngIf="!readonly && !this.allItems.length"
+                 (click)="addItem()"
+                 [disabled]="!isAddAllowed()">
+    {{ addLabel }}
+</mad-link-button>

--- a/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.ts
+++ b/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.ts
@@ -1,0 +1,17 @@
+import {
+  ChangeDetectorRef,
+  Component,
+} from '@angular/core';
+import { BaseQuickListComponent, QuickListItem } from '../base-quick-list.component';
+
+@Component({
+  selector: 'mad-quick-list-compact',
+  templateUrl: './quick-list-compact.component.html',
+  styleUrls: [],
+})
+export class QuickListCompactComponent extends BaseQuickListComponent<QuickListItem> {
+
+  constructor(public changeDetectorRef: ChangeDetectorRef) {
+    super(changeDetectorRef);
+  }
+}

--- a/projects/material-addons/src/lib/quick-list/quick-list.component.html
+++ b/projects/material-addons/src/lib/quick-list/quick-list.component.html
@@ -4,12 +4,12 @@
 <ng-container *ngFor="let item of allItems">
   <div *ngIf="itemTemplate" #row>
     <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
-    <mad-icon-button *ngIf="!(readonly || readonly === '')" [disabled]="!isDeleteAllowed()" (click)="removeItem(item)">
+    <mad-icon-button *ngIf="!readonly && isDeleteAllowed()" (click)="removeItem(item)">
       <mat-icon>delete</mat-icon>
     </mad-icon-button>
   </div>
 </ng-container>
-<mad-link-button *ngIf="!(readonly || readonly === '')" (click)="addItem()"
+<mad-link-button *ngIf="!readonly" (click)="addItem()"
                  [disabled]="!addPossible || !isAddAllowed()">
   {{ addLabel }}
 </mad-link-button>

--- a/projects/material-addons/src/lib/quick-list/quick-list.component.ts
+++ b/projects/material-addons/src/lib/quick-list/quick-list.component.ts
@@ -1,107 +1,15 @@
 // Based on https://github.com/porscheinformatik/clarity-addons/blob/master/src/clr-addons/generic-quick-list/generic-quick-list.ts
 
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  ContentChild,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  QueryList,
-  TemplateRef,
-  ViewChildren,
-} from '@angular/core';
-
-export interface QuickListItem {
-  id: string;
-}
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { BaseQuickListComponent, QuickListItem } from './base-quick-list.component';
 
 @Component({
   selector: 'mad-quick-list',
   templateUrl: './quick-list.component.html',
   styleUrls: [],
 })
-export class QuickListComponent<T extends QuickListItem> implements OnInit, AfterViewInit {
-  @Input() allItems = [] as T[];
-  @Input() addLabel = 'NOT SET';
-  @Input() addPossible = true;
-  @Input() blankItem = {} as any;
-  @Input() readonly: string;
-  @Input() maxItems: number;
-  @Input() minItems: number;
-
-  @Output() added = new EventEmitter<T>();
-  @Output() removed = new EventEmitter<T>();
-  @ContentChild(TemplateRef) itemTemplate: TemplateRef<any>;
-  @ViewChildren('row') itemRows: QueryList<ElementRef>;
-
-  rowCountFocus: number;
-  addEventFunction: Function;
-
-  constructor(private changeDetectorRef: ChangeDetectorRef) {}
-
-  ngOnInit(): void {
-    this.addEventFunction = this.addItem.bind(this);
-    if (typeof this.minItems !== 'undefined') {
-      for (let n = this.allItems.length; n < this.minItems; n++) {
-        this.interalAddItem();
-      }
-    }
-  }
-
-  ngAfterViewInit(): void {
-    setTimeout(() => this.setFocusOnAdd(), 1);
-  }
-
-  addItem(): void {
-    const newItem = this.interalAddItem();
-    if (!!newItem) {
-      this.added.emit(newItem);
-    }
-  }
-
-  removeItem(item: T): void {
-    if (this.isDeleteAllowed()) {
-      this.allItems.splice(this.allItems.indexOf(item), 1);
-      this.removed.emit(item);
-    }
-  }
-
-  setFocusOnAdd(): void {
-    this.rowCountFocus = this.itemRows.length;
-    this.itemRows.changes.subscribe((els: QueryList<ElementRef>) => {
-      if (els.length > this.rowCountFocus && !!els.last) {
-        const firstFocusable = els.last.nativeElement.querySelector("button, a, input, select, textarea, [tabindex]:not([tabindex='-1'])");
-        if (firstFocusable) {
-          firstFocusable.focus();
-        }
-      }
-      this.rowCountFocus = els.length;
-    });
-  }
-
-  isAddAllowed(): boolean {
-    return typeof this.maxItems === 'undefined' || this.allItems.length < this.maxItems;
-  }
-
-  isDeleteAllowed(): boolean {
-    return typeof this.minItems === 'undefined' || this.allItems.length > this.minItems;
-  }
-
-  private interalAddItem(): T {
-    if (this.isAddAllowed()) {
-      const newItem = { ...this.blankItem };
-      // creates ids in the form of "n5kdz1pljl8"
-      newItem.id = Math.random()
-        .toString(36)
-        .substring(2);
-      this.allItems.push(newItem);
-      this.changeDetectorRef.detectChanges();
-      return newItem;
-    }
-    return null;
+export class QuickListComponent extends BaseQuickListComponent<QuickListItem> {
+  constructor(public changeDetectorRef: ChangeDetectorRef) {
+    super(changeDetectorRef);
   }
 }

--- a/projects/material-addons/src/lib/quick-list/quick-list.module.ts
+++ b/projects/material-addons/src/lib/quick-list/quick-list.module.ts
@@ -3,11 +3,13 @@ import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { QuickListComponent } from './quick-list.component';
-import {ButtonModule} from "../button/button.module";
+import { ButtonModule } from '../button/button.module';
+import { BaseQuickListComponent } from './base-quick-list.component';
+import { QuickListCompactComponent } from './quick-list-compact/quick-list-compact.component';
 
 @NgModule({
-  declarations: [QuickListComponent],
+  declarations: [QuickListComponent, BaseQuickListComponent, QuickListCompactComponent],
   imports: [CommonModule, MatButtonModule, MatIconModule, ButtonModule],
-  exports: [QuickListComponent],
+  exports: [QuickListComponent, QuickListCompactComponent, BaseQuickListComponent],
 })
 export class QuickListModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -76,6 +76,7 @@ import { MadButtonsComponent } from './example-components/mad-buttons/mad-button
 import { MadButtonsDemoComponent } from './component-demos/mad-buttons-demo/mad-buttons-demo.component';
 import { ThrottleClickComponent } from './example-components/throttle-click/throttle-click.component';
 import { ThrottleClickDemoComponent } from './component-demos/throttle-click-demo/throttle-click-demo.component';
+import {QuickListCompactBasicComponent} from './example-components/quick-list-compact-basic/quick-list-compact-basic.component';
 
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
   return new TranslateHttpLoader(http, './assets/i18n/');
@@ -118,6 +119,7 @@ export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
     MadButtonsDemoComponent,
     ThrottleClickComponent,
     ThrottleClickDemoComponent,
+    QuickListCompactBasicComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/component-demos/quick-list-demo/quick-list-demo.component.html
+++ b/src/app/component-demos/quick-list-demo/quick-list-demo.component.html
@@ -11,8 +11,10 @@
   <li>click on "Add option", adds another empty input-row</li>
   <li>click on "trashbin-icon", removes input-row</li>
   <ul>
-    <li>last item, input mandatory: "trashbin-icon" is disabled</li>
+    <li>last item, input mandatory: "trashbin-icon" is hidden</li>
+    <li>minItems defined, the "trashbin-icon" is hidden, when only minimum items available in quick list</li>
     <li>last item, input optional: input-row is removed, only "ADD OPTION" remains.</li>
+
   </ul>
 </ul>
 <p>
@@ -23,9 +25,15 @@
 <p>
   Basic usage with optional values and no limits
 </p>
-<example-viewer [example]="basicQuickListComponent"></example-viewer> 
-
+<example-viewer [example]="basicQuickListComponent"></example-viewer>
+<br>
 <p>
   Required value for last name and minimal 2 and maximal 5 entries set.
 </p>
-<example-viewer [example]="extendedQuickListComponent"></example-viewer> 
+<example-viewer [example]="extendedQuickListComponent"></example-viewer>
+<br>
+<p>
+  With<app-text-code>&lt;mad-quick-list-compact&gt;</app-text-code> there is also an compact version of the quick list.
+  The "add"-Button gets replaced with an "plus-icon" in the last row
+</p>
+<example-viewer [example]="compactQuickListComponent"></example-viewer>

--- a/src/app/component-demos/quick-list-demo/quick-list-demo.component.ts
+++ b/src/app/component-demos/quick-list-demo/quick-list-demo.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { QuickListBasicComponent } from '../../example-components/quick-list-basic/quick-list-basic.component';
 import { Example } from '../../components/example-viewer/example.class';
 import { QuickListExtendedComponent } from '../../example-components/quick-list-extended/quick-list-extended.component';
+import { QuickListCompactBasicComponent } from '../../example-components/quick-list-compact-basic/quick-list-compact-basic.component';
 
 @Component({
   selector: 'app-quick-list-demo',
@@ -11,5 +12,6 @@ import { QuickListExtendedComponent } from '../../example-components/quick-list-
 export class QuickListDemoComponent {
   basicQuickListComponent = new Example(QuickListBasicComponent, 'quick-list-basic', 'Quick List Basic');
   extendedQuickListComponent = new Example(QuickListExtendedComponent, 'quick-list-extended', 'Quick List Extended');
+  compactQuickListComponent = new Example(QuickListCompactBasicComponent, 'quick-list-compact-basic', 'Quick List Compact');
 
 }

--- a/src/app/example-components/quick-list-compact-basic/quick-list-compact-basic.component.html
+++ b/src/app/example-components/quick-list-compact-basic/quick-list-compact-basic.component.html
@@ -1,0 +1,40 @@
+<div class="input-wrapper">
+  <mat-checkbox [checked]="textIsEditable" (change)="textIsEditable = !textIsEditable">
+    Text editable
+  </mat-checkbox>
+
+  <form #form="ngForm">
+    <mad-quick-list-compact
+      addLabel="Add Item"
+      [allItems]="items"
+      [addPossible]="form.valid"
+      [readonly]="!textIsEditable"
+      [maxItems]="5"
+      [minItems]="1"
+      (added)="onItemAdded($event)"
+      (removed)="onItemRemoved($event)">
+      <label>Enter some names</label>
+      <ng-template let-item>
+        <!-- Custom content below -->
+        <div fxFlex fxLayout="row" fxLayoutAlign="space-between">
+          <mad-readonly-form-field-wrapper fxFlex [value]="item.firstName" [readonly]="!textIsEditable">
+            <mat-form-field class="form-group">
+              <mat-label>First Name</mat-label>
+              <input [(ngModel)]="item.firstName" [name]="'firstName-' + item.id" autocomplete="off" class="form-control" matInput />
+            </mat-form-field>
+          </mad-readonly-form-field-wrapper>
+
+          <mad-readonly-form-field-wrapper fxFlex [value]="item.lastName" [readonly]="!textIsEditable">
+            <mat-form-field class="form-group">
+              <mat-label>Last Name</mat-label>
+              <input [(ngModel)]="item.lastName" [name]="'lastName-' + item.id" autocomplete="off" class="form-control" matInput required />
+              <mat-error>
+                Please enter a last name
+              </mat-error>
+            </mat-form-field>
+          </mad-readonly-form-field-wrapper>
+        </div>
+      </ng-template>
+    </mad-quick-list-compact>
+  </form>
+</div>

--- a/src/app/example-components/quick-list-compact-basic/quick-list-compact-basic.component.scss
+++ b/src/app/example-components/quick-list-compact-basic/quick-list-compact-basic.component.scss
@@ -1,0 +1,8 @@
+mad-readonly-form-field-wrapper:not(:first-child) {
+  margin-left: 2em;
+}
+
+.input-wrapper {
+  width: 20em;
+  margin-bottom: 2em;
+}

--- a/src/app/example-components/quick-list-compact-basic/quick-list-compact-basic.component.ts
+++ b/src/app/example-components/quick-list-compact-basic/quick-list-compact-basic.component.ts
@@ -7,11 +7,11 @@ interface QuickListDemoItem extends QuickListItem {
 }
 
 @Component({
-  selector: 'app-quick-list-basic',
-  templateUrl: './quick-list-basic.component.html',
-  styleUrls: ['./quick-list-basic.component.scss'],
+  selector: 'app-quick-list-compact',
+  templateUrl: './quick-list-compact-basic.component.html',
+  styleUrls: ['./quick-list-compact-basic.component.scss'],
 })
-export class QuickListBasicComponent {
+export class QuickListCompactBasicComponent {
   items = [{ id: '1' } as QuickListDemoItem];
   textIsEditable = true;
 

--- a/src/app/example-components/quick-list-extended/quick-list-extended.component.ts
+++ b/src/app/example-components/quick-list-extended/quick-list-extended.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { QuickListItem } from '@porscheinformatik/material-addons/lib/quick-list/quick-list.component';
+import { QuickListItem } from '@porscheinformatik/material-addons/lib/quick-list/base-quick-list.component';
 
 interface QuickListDemoItem extends QuickListItem {
   firstName: string;


### PR DESCRIPTION

### Description

Enhancement of the quicklist as aligned with @d-m-s (#83 and #84)

1. Changed the behavior of the "trashbin-icon" when min items reached. Instead of disabling it the icon isn't being displayed anymore
2. Extracted the base functionality of the quick list to a base component and implemented the "quick list compact"

### Which Component is affected or generated?

Material Addons Quicklist
