### PR TITLE
added setting translateLabels to data-table to turn off/on the translations pipe

### DIFF
--- a/projects/material-addons/src/lib/data-table/data-table.component.html
+++ b/projects/material-addons/src/lib/data-table/data-table.component.html
@@ -6,12 +6,12 @@
       class="table-action"
       *ngFor="let tableAction of tableActions"
       (click)="onTableAction(tableAction)">
-      {{ tableAction.label | translate }} {{ getSelectedCount(tableAction.type) }}
+      {{ translateLabels ? (tableAction.label | translate) : tableAction.label }} {{ getSelectedCount(tableAction.type) }}
     </mad-outline-button>
   </div>
   <!-- Table filter -->
   <mat-form-field *ngIf="isFilterEnabled">
-    <mat-label>{{ filterLabel | translate }}</mat-label>
+    <mat-label>{{ translateLabels ? (filterLabel | translate) : filterLabel }}</mat-label>
     <input matInput autocomplete="off" (keyup)="setFilterValue($event?.target?.value)"
            placeholder="{{ filterPlaceholder }}" />
   </mat-form-field>
@@ -23,7 +23,7 @@
   <ng-template matMenuContent let-element="element">
     <button *ngFor="let rowAction of rowActions" mat-menu-item class="row-action"
             (click)="onRowEvent($event, element, rowAction)">
-      {{ rowAction.label | translate }}
+      {{ translateLabels ? (rowAction.label | translate) : rowAction.label }}
     </button>
   </ng-template>
 </mat-menu>
@@ -37,7 +37,7 @@
             (click)="onColumnSettings(definition)"
             [ngClass]="{'active-column-definition': isCurrentDefinition(definition)}"
     >
-      {{ definition.label | translate }}
+      {{ translateLabels ? (definition.label | translate) : definition.label }}
     </button>
   </ng-template>
 </mat-menu>
@@ -51,7 +51,7 @@
             (click)="onViewDefinition(definition)"
             [ngClass]="{'active-column-definition': isCurrentDefinition(definition)}"
     >
-      {{ definition.label | translate }}
+      {{ translateLabels ? (definition.label | translate) : definition.label }}
     </button>
   </ng-template>
 </mat-menu>
@@ -106,12 +106,12 @@
           [arrowPosition]="column.isRightAligned ? 'before' : 'after'"
           [class.text-right]="column.isRightAligned"
         >
-          {{ column.label | translate }}
+          {{ translateLabels ? (column.label | translate) : column.label }}
         </th>
       </ng-container>
       <ng-template #noSort>
         <th scope="col" mat-header-cell *matHeaderCellDef [class.text-right]="column.isRightAligned">
-          {{ column.label | translate }}
+          {{ translateLabels ? (column.label | translate) : column.label }}
         </th>
       </ng-template>
       <td mat-cell *matCellDef="let element" [class.text-right]="column.isRightAligned" [ngSwitch]="column.transformer">

--- a/projects/material-addons/src/lib/data-table/data-table.component.ts
+++ b/projects/material-addons/src/lib/data-table/data-table.component.ts
@@ -40,6 +40,7 @@ export class DataTableComponent implements OnInit, AfterViewInit {
   @Input() deleteDefinitionAllowed = false;
 
   @Input() useAsync = false;
+  @Input() translateLabels = true;
 
   @Input() set displayedColumns(cols: DataTableColumn[]) {
     if (!this.displayedColumnDefinition) {

--- a/src/app/example-components/data-table-example-data/data-table-example-data.ts
+++ b/src/app/example-components/data-table-example-data/data-table-example-data.ts
@@ -1151,6 +1151,13 @@ const summaryData = [
     description: 'Function: provide a static function that generates an ID for a row (see example above)',
   },
   {
+    name: '[translateLabels]',
+    inOut: 'input',
+    type: 'boolean',
+    defaultValue: "'true'",
+    description: 'Setting: if false, labels will not be translated',
+  },
+  {
     name: '(actionEvent)',
     inOut: 'output',
     type: 'DataTableAction',


### PR DESCRIPTION
…ation pipe (#115)

### Description

There might be projects/use cases where a custom MissingTranslationHeader is implemented, which for example displays a message if a translation key is not found. When using the translate pipe, the labels in the data-table component will be translated and this will cause issues (because it would display that error/warning message in the table). 

By setting the [translateLabels]="false" the data-table will display the labels as they where passed, if [translateLabels]="true" (default), it will translate the labels

### Which Component is affected or generated?

data-table