### PR TITLE
fix: data-table row actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
     },
     "dist/material-addons": {
       "name": "@porscheinformatik/material-addons",
-      "version": "15.0.2",
+      "version": "15.0.3",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/projects/material-addons/src/lib/data-table/data-table.component.html
+++ b/projects/material-addons/src/lib/data-table/data-table.component.html
@@ -78,7 +78,9 @@
       </th>
       <td mat-cell *matCellDef="let element" [ngClass]="mode === NONE ? 'no-action-cell' : 'row-action-cell'">
         <!-- BATCH: row checkbox -->
-        <div *ngIf="!element.parentId && (mode === BATCH)" class="mad-datatable-checkbox-container">
+        <div *ngIf="!element.parentId && (mode === BATCH)" class="mad-datatable-checkbox-container"
+             (click)="onRowEvent($event, element)"
+        >
           <mat-checkbox
             class="no-pointer-events"
             [checked]="isSelected(element.rowId)"
@@ -116,7 +118,10 @@
         </th>
       </ng-template>
       <!-- data cell to be injected -->
-      <td mat-cell *matCellDef="let element" [class.text-right]="column.isRightAligned" [class.mad-dt-child-cell]="element.parentId" [ngSwitch]="column.transformer">
+      <td mat-cell *matCellDef="let element"
+          [class.text-right]="column.isRightAligned" [class.mad-dt-child-cell]="element.parentId"
+          [ngSwitch]="column.transformer" (click)="onRowEvent($event, element)"
+      >
         <span>
           {{ element[column.dataPropertyName] }}
         </span>
@@ -128,7 +133,6 @@
     <tr
       mat-row
       [class.clickable-table-row]="!row.parentId && isRowClickable"
-      (click)="onRowEvent($event, row)"
       *matRowDef="let row; columns: columnIds"
     ></tr>
   </table>


### PR DESCRIPTION
### Description

data table row action: when menu button is clicked, default action is executed (=row click event) before the menu is opened (affects material 15+)

### Which Component is affected or generated?

data-table
