### PR TITLE
add jest unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+// Jest configuration
+module.exports = {
+  preset: 'jest-preset-angular',
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
+  globalSetup: 'jest-preset-angular/global-setup',
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "eslint:mat-add:fix": "eslint projects/material-addons/src/**/*.ts --fix",
     "prettier": "prettier -c src/**/* projects/material-addons/src/**/* --write",
     "build-and-serve": "npm install && npm run build:mat-add && npm install --no-optional && npm install && ng serve --open",
-    "serve": "ng serve --open"
+    "serve": "ng serve --open",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "private": true,
   "dependencies": {
@@ -33,18 +36,19 @@
     "@angular/platform-browser": "17.0.4",
     "@angular/platform-browser-dynamic": "17.0.4",
     "@angular/router": "17.0.4",
-    "rxjs": "~7.8.1",
-    "tslib": "^2.6.0",
-    "zone.js": "~0.14.2",
     "@ngx-translate/core": "^15.0.0",
     "@ngx-translate/http-loader": "^8.0.0",
     "material-icons": "^1.13.9",
-    "roboto-fontface": "^0.10.0"
+    "roboto-fontface": "^0.10.0",
+    "rxjs": "~7.8.1",
+    "tslib": "^2.6.0",
+    "zone.js": "~0.14.2"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "17.0.3",
     "@angular/cli": "17.0.3",
     "@angular/compiler-cli": "17.0.4",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.4.4",
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -52,12 +56,15 @@
     "eslint": "^8.55.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
+    "jest": "^29.7.0",
     "ncp": "^2.0.0",
     "ng-packagr": "^17.0.2",
     "prettier": "^3.1.1",
+    "ts-jest": "^29.1.2",
     "ts-node": "~10.9.1",
     "typescript": "~5.2.2",
-    "uuid": "9.0.0"
+    "uuid": "9.0.0",
+    "jest-preset-angular": "^14.0.0"
   },
   "optionalDependencies": {
     "@porscheinformatik/material-addons": "file:dist/material-addons"

--- a/projects/material-addons/src/lib/button/danger-button/danger-button.component.spec.ts
+++ b/projects/material-addons/src/lib/button/danger-button/danger-button.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DangerButtonComponent } from './danger-button.component';
+
+describe('DangerButtonComponent', () => {
+  it('should create', () => {
+    const fixture = TestBed.createComponent(DangerButtonComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should disable the button', () => {
+    TestBed.overrideComponent(DangerButtonComponent, {
+      set: {
+        template: '<mad-danger-button [disabled]="true"></mad-danger-button>',
+      },
+    });
+
+    const fixture = TestBed.createComponent(DangerButtonComponent);
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('mad-danger-button'));
+    expect(button.nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should be enabled by default', () => {
+    const fixture = TestBed.createComponent(DangerButtonComponent);
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button.nativeElement.disabled).toBeFalsy();
+  });
+
+  it('should set the title', () => {
+    const fixture = TestBed.createComponent(DangerButtonComponent);
+    const component = fixture.componentInstance;
+    component.title = 'Test Title';
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button.nativeElement.title).toEqual('Test Title');
+  });
+});

--- a/projects/material-addons/src/lib/button/flat-button/link.button.component.spec.ts
+++ b/projects/material-addons/src/lib/button/flat-button/link.button.component.spec.ts
@@ -1,6 +1,6 @@
-import {TestBed} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
-import {LinkButtonComponent} from './link-button.component';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { LinkButtonComponent } from './link-button.component';
 
 describe('LinkButtonComponent', () => {
   it('should create', () => {

--- a/projects/material-addons/src/lib/button/flat-button/link.button.component.spec.ts
+++ b/projects/material-addons/src/lib/button/flat-button/link.button.component.spec.ts
@@ -1,0 +1,58 @@
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {LinkButtonComponent} from './link-button.component';
+
+describe('LinkButtonComponent', () => {
+  it('should create', () => {
+    const fixture = TestBed.createComponent(LinkButtonComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should have pointer-events auto and opacity 1 if disabled is false', () => {
+    const fixture = TestBed.createComponent(LinkButtonComponent);
+    const component = fixture.componentInstance;
+    expect(component.pointerEvent).toBe('auto');
+    expect(component.opacity).toBe('1');
+  });
+
+  it('should have pointer-events none and opacity 0.35 if disabled is true', () => {
+    const fixture = TestBed.createComponent(LinkButtonComponent);
+    const component = fixture.componentInstance;
+    component.disabled = true;
+    fixture.detectChanges();
+
+    expect(component.pointerEvent).toBe('none');
+    expect(component.opacity).toBe('0.35');
+  });
+
+  it('should disable the button', () => {
+    TestBed.overrideComponent(LinkButtonComponent, {
+      set: {
+        template: '<mad-link-button [disabled]="true"></mad-link-button>',
+      },
+    });
+
+    const fixture = TestBed.createComponent(LinkButtonComponent);
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('mad-link-button'));
+    expect(button.nativeElement.disabled).toBeTruthy();
+  });
+
+  it('should be enabled by default', () => {
+    const fixture = TestBed.createComponent(LinkButtonComponent);
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button.nativeElement.disabled).toBeFalsy();
+  });
+
+  it('should set the title', () => {
+    const fixture = TestBed.createComponent(LinkButtonComponent);
+    const component = fixture.componentInstance;
+    component.title = 'Test Title';
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button.nativeElement.title).toEqual('Test Title');
+  });
+});

--- a/projects/material-addons/src/lib/button/mad-button-group/mad-button-group.component.spec.ts
+++ b/projects/material-addons/src/lib/button/mad-button-group/mad-button-group.component.spec.ts
@@ -1,0 +1,30 @@
+import {MadButtonGroupComponent} from './mad-button-group.component';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+describe('MadButtonGroupComponent', () => {
+  let component: MadButtonGroupComponent;
+  let fixture: ComponentFixture<MadButtonGroupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MadButtonGroupComponent ]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MadButtonGroupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have class mad-button-group', () => {
+    const hostElement = fixture.nativeElement;
+    const className = hostElement.className;
+    expect(className).toEqual('mad-button-group');
+  });
+});

--- a/projects/material-addons/src/lib/button/mad-button-group/mad-button-group.component.spec.ts
+++ b/projects/material-addons/src/lib/button/mad-button-group/mad-button-group.component.spec.ts
@@ -1,5 +1,5 @@
-import {MadButtonGroupComponent} from './mad-button-group.component';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import { MadButtonGroupComponent } from './mad-button-group.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 describe('MadButtonGroupComponent', () => {
   let component: MadButtonGroupComponent;
@@ -7,9 +7,8 @@ describe('MadButtonGroupComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ MadButtonGroupComponent ]
-    })
-      .compileComponents();
+      declarations: [MadButtonGroupComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/projects/material-addons/src/lib/button/mad-button/mad-button.directive.spec.ts
+++ b/projects/material-addons/src/lib/button/mad-button/mad-button.directive.spec.ts
@@ -1,0 +1,52 @@
+import { MadButtonDirective } from './mad-button.directive';
+import {ElementRef, Renderer2} from '@angular/core';
+import { MatButton } from '@angular/material/button';
+
+describe('MadButtonDirective', () => {
+  let directive: MadButtonDirective;
+  let el: ElementRef;
+  let button: MatButton;
+  let renderer2: Renderer2;
+
+  beforeEach(() => {
+    el = {
+      nativeElement: document.createElement('button')
+    };
+    button = { color: '' } as MatButton;
+    renderer2 = {
+      addClass: jest.fn(),
+      removeClass: jest.fn()
+    } as unknown as Renderer2;
+
+    directive = new MadButtonDirective(renderer2, el, null, button);
+  });
+
+  it('should create an instance', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  it('should set color during initialization', () => {
+    directive.color = 'accent';
+    directive.ngOnInit();
+    expect(button.color).toBe('accent');
+  });
+
+  it('should default color to primary if not provided', () => {
+    directive.ngOnInit();
+    expect(button.color).toBe('primary');
+  });
+
+  it('should add and remove outline class based on input', () => {
+    directive.outline = true;
+    expect(renderer2.addClass).toHaveBeenCalledWith(el.nativeElement, 'mad-outline');
+    directive.outline = false;
+    expect(renderer2.removeClass).toHaveBeenCalledWith(el.nativeElement, 'mad-outline');
+  });
+
+  it('should add and remove uppercase class based on input', () => {
+    directive.uppercase = true;
+    expect(renderer2.addClass).toHaveBeenCalledWith(el.nativeElement, 'mad-uppercase');
+    directive.uppercase = false;
+    expect(renderer2.removeClass).toHaveBeenCalledWith(el.nativeElement, 'mad-uppercase');
+  });
+});

--- a/projects/material-addons/src/lib/button/mad-button/mad-button.directive.spec.ts
+++ b/projects/material-addons/src/lib/button/mad-button/mad-button.directive.spec.ts
@@ -1,5 +1,5 @@
 import { MadButtonDirective } from './mad-button.directive';
-import {ElementRef, Renderer2} from '@angular/core';
+import { ElementRef, Renderer2 } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 
 describe('MadButtonDirective', () => {
@@ -10,12 +10,12 @@ describe('MadButtonDirective', () => {
 
   beforeEach(() => {
     el = {
-      nativeElement: document.createElement('button')
+      nativeElement: document.createElement('button'),
     };
     button = { color: '' } as MatButton;
     renderer2 = {
       addClass: jest.fn(),
-      removeClass: jest.fn()
+      removeClass: jest.fn(),
     } as unknown as Renderer2;
 
     directive = new MadButtonDirective(renderer2, el, null, button);

--- a/projects/material-addons/src/lib/card/card.component.html
+++ b/projects/material-addons/src/lib/card/card.component.html
@@ -3,13 +3,13 @@
     <mat-card-title-group class="center">
       <mat-card-title class="small-title-container">{{ title }}</mat-card-title>
       <div class="top-right-icons">
-        <mad-icon-button (click)="toggleCollapse()" *ngIf="expandable && !editMode">
+        <mad-icon-button data-testid="collapse-btn" (click)="toggleCollapse()" *ngIf="expandable && !editMode">
           <mat-icon [@rotateIcon]="!expanded">keyboard_arrow_down</mat-icon>
         </mad-icon-button>
-        <mad-icon-button (click)="additionalActionClicked()" *ngIf="additionalActionIcon" [title]="additionalActionText" type="button">
+        <mad-icon-button data-testid="additional-btn" (click)="additionalActionClicked()" *ngIf="additionalActionIcon" [title]="additionalActionText" type="button">
           <mat-icon>{{ additionalActionIcon }}</mat-icon>
         </mad-icon-button>
-        <mad-icon-button [title]="editText" (click)="onEdit()" *ngIf="!readonly && !editMode">
+        <mad-icon-button data-testid="edit-btn" [title]="editText" (click)="onEdit()" *ngIf="!readonly && !editMode">
           <mat-icon>create</mat-icon>
         </mad-icon-button>
       </div>
@@ -19,10 +19,10 @@
     <ng-content></ng-content>
   </mat-card-content>
   <mat-card-actions *ngIf="!readonly && editMode">
-    <mad-primary-button [title]="saveText" [disabled]="saveDisabled" (throttleClick)="onSave()" madThrottleClick>
+    <mad-primary-button data-testid="save-btn" [title]="saveText" [disabled]="saveDisabled" (throttleClick)="onSave()" madThrottleClick>
       {{ saveText }}
     </mad-primary-button>
-    <mad-outline-button [title]="cancelText" [disabled]="cancelDisabled" (click)="onCancel()">
+    <mad-outline-button data-testid="cancel-btn" [title]="cancelText" [disabled]="cancelDisabled" (click)="onCancel()">
       {{ cancelText }}
     </mad-outline-button>
   </mat-card-actions>

--- a/projects/material-addons/src/lib/card/card.component.spec.ts
+++ b/projects/material-addons/src/lib/card/card.component.spec.ts
@@ -5,7 +5,6 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { ButtonModule } from '../button/button.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component } from '@angular/core';
 
 describe('CardComponent', () => {
   let component: CardComponent;

--- a/projects/material-addons/src/lib/card/card.component.spec.ts
+++ b/projects/material-addons/src/lib/card/card.component.spec.ts
@@ -1,0 +1,178 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { CardComponent } from './card.component';
+import { By } from '@angular/platform-browser';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { ButtonModule } from '../button/button.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Component } from '@angular/core';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CardComponent],
+      imports: [MatCardModule, MatIconModule, ButtonModule, NoopAnimationsModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create CardComponent', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call onEdit when edit button is clicked', () => {
+    jest.spyOn(component, 'onEdit');
+    // Set the conditions to enable the button
+    component.readonly = false;
+    component.editMode = false;
+    component.expanded = false;
+    fixture.detectChanges();
+
+    const editButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="edit-btn"]'));
+    expect(editButtonDebugElement).toBeDefined();
+    editButtonDebugElement.triggerEventHandler('click', null);
+    expect(component.onEdit).toHaveBeenCalledTimes(1);
+    expect(component.expanded).toBeTruthy();
+  });
+
+  it('should not render the edit button when readOnly and editMode are true', () => {
+    // Set the conditions to disable the button
+    component.readonly = true;
+    component.editMode = true;
+    fixture.detectChanges();
+
+    const editButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="edit-btn"]'));
+    expect(editButtonDebugElement).toBeNull();
+  });
+
+  it('should call onCancel method when cancel is triggered', () => {
+    jest.spyOn(component, 'onCancel');
+    // Set the conditions to enable the button
+    component.readonly = false;
+    component.editMode = true;
+    fixture.detectChanges();
+
+    const cancelButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="cancel-btn"]'));
+    expect(cancelButtonDebugElement).toBeDefined();
+    cancelButtonDebugElement.triggerEventHandler('click', null);
+    expect(component.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel should be disabled when cancelDisabled is true', async () => {
+    jest.spyOn(component, 'onCancel');
+    // Set the conditions to disable the button
+    component.readonly = false;
+    component.editMode = true;
+    component.cancelDisabled = true;
+    fixture.detectChanges();
+
+    const cancelButtonElement = fixture.debugElement.query(By.css('[data-testid="cancel-btn"]'));
+    expect(cancelButtonElement).toBeDefined();
+    expect(cancelButtonElement.nativeElement.getAttribute('ng-reflect-disabled')).toBeTruthy();
+  });
+
+  it('should call onSave method when save is triggered', () => {
+    jest.spyOn(component, 'onSave');
+    // Set the conditions to enable the button
+    component.readonly = false;
+    component.editMode = true;
+    fixture.detectChanges();
+
+    const saveButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="save-btn"]'));
+    saveButtonDebugElement.triggerEventHandler('throttleClick', null);
+    expect(component.onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel and save buttons should not be visible', () => {
+    // Set the conditions to hide the buttons
+    component.readonly = true;
+    component.editMode = false;
+    fixture.detectChanges();
+
+    const cardActionsDebugElement = fixture.debugElement.query(By.css('mat-card-actions'));
+    expect(cardActionsDebugElement).toBeNull();
+  });
+
+  it('cancel and save buttons should be visible', () => {
+    // Set the conditions to show the buttons
+    component.readonly = false;
+    component.editMode = true;
+    fixture.detectChanges();
+
+    const cardActionsDebugElement = fixture.debugElement.query(By.css('mat-card-actions'));
+    const saveButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="save-btn"]'));
+    const cancelButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="cancel-btn"]'));
+    expect(cardActionsDebugElement).toBeDefined();
+    expect(saveButtonDebugElement).toBeDefined();
+    expect(cancelButtonDebugElement).toBeDefined();
+  });
+
+  it('toggleCollapse method should toggle the expandable', () => {
+    jest.spyOn(component, 'toggleCollapse');
+    // Set the conditions to enable the button
+    component.expandable = true;
+    component.expanded = false;
+    component.editMode = false;
+    fixture.detectChanges();
+
+    const toggleButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="collapse-btn"]'));
+    toggleButtonDebugElement.triggerEventHandler('click', null);
+    expect(component.toggleCollapse).toHaveBeenCalledTimes(1);
+    expect(component.expanded).toBe(true);
+  });
+
+  it('should show mat-card-content when expanded is true', () => {
+    // Set expanded as true
+    component.expanded = true;
+    fixture.detectChanges();
+
+    const contentDebugElement = fixture.debugElement.query(By.css('mat-card-content'));
+    expect(contentDebugElement).toBeDefined();
+  });
+
+  it('should not show mat-card-content when expanded is false', () => {
+    // Set expanded as false
+    component.expanded = false;
+    fixture.detectChanges();
+
+    const contentDebugElement = fixture.debugElement.query(By.css('mat-card-content'));
+    expect(contentDebugElement).toBeNull();
+  });
+
+  it('should display additional button when additionalActionIcon is specified', () => {
+    // Set value for additionalActionIcon
+    component.additionalActionIcon = 'someIcon';
+    fixture.detectChanges();
+
+    const buttonDebugElement = fixture.debugElement.query(By.css('[data-testid="additional-btn"]'));
+    expect(buttonDebugElement).toBeDefined();
+  });
+
+  it('should not display additional button when additionalActionIcon is not specified', () => {
+    // Set no value for additionalActionIcon
+    component.additionalActionIcon = '';
+    fixture.detectChanges();
+
+    const buttonDebugElement = fixture.debugElement.query(By.css('[data-testid="additional-btn"]'));
+    expect(buttonDebugElement).toBeNull();
+  });
+
+  it('should call additionalActionClicked() when additional button is clicked', () => {
+    jest.spyOn(component, 'additionalActionClicked');
+    // Set some value for additionalActionIcon
+    component.additionalActionIcon = 'someText';
+    fixture.detectChanges();
+
+    const additionalButtonDebugElement = fixture.debugElement.query(By.css('[data-testid="additional-btn"]'));
+    additionalButtonDebugElement.triggerEventHandler('click', null);
+    expect(component.additionalActionClicked).toHaveBeenCalledTimes(1);
+  });
+});

--- a/projects/material-addons/src/lib/data-table/data-table-columns-modal/data-table-columns-modal.component.spec.ts
+++ b/projects/material-addons/src/lib/data-table/data-table-columns-modal/data-table-columns-modal.component.spec.ts
@@ -36,7 +36,11 @@ describe('DataTableColumnsModalComponent', () => {
 
   it('should initialize selected columns based on definition and allColumns', () => {
     const clearFilterValueSpy = jest.spyOn(component, 'clearFilterValue');
-    dialogDataMock.definition =  { displayedColumns: [{ id: '1', label: 'Test Column 1', dataPropertyName: 'test1' }], id: '1', label: 'firstDefinition' };
+    dialogDataMock.definition = {
+      displayedColumns: [{ id: '1', label: 'Test Column 1', dataPropertyName: 'test1' }],
+      id: '1',
+      label: 'firstDefinition',
+    };
     component.ngOnInit();
     expect(component.selectedColumns).toEqual([{ id: '1', label: 'Test Column 1', dataPropertyName: 'test1' }]);
     expect(component.availableColumns).toEqual([{ id: '2', label: 'Test Column 2', dataPropertyName: 'test2' }]);

--- a/projects/material-addons/src/lib/data-table/data-table-columns-modal/data-table-columns-modal.component.spec.ts
+++ b/projects/material-addons/src/lib/data-table/data-table-columns-modal/data-table-columns-modal.component.spec.ts
@@ -1,0 +1,139 @@
+import { DataTableColumnsModalComponent } from './data-table-columns-modal.component';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { DataTableColumn } from '../data-table-column';
+
+describe('DataTableColumnsModalComponent', () => {
+  let component: DataTableColumnsModalComponent;
+  let dialogRefMock: any;
+  let dialogDataMock: any;
+
+  beforeEach(() => {
+    dialogRefMock = { close: jest.fn() };
+    dialogDataMock = {
+      definition: { displayedColumns: [], id: '1' },
+      allColumns: [
+        { id: '1', label: 'Test Column 1', dataPropertyName: 'test1' },
+        { id: '2', label: 'Test Column 2', dataPropertyName: 'test2' },
+      ],
+    };
+    component = new DataTableColumnsModalComponent(dialogRefMock, dialogDataMock);
+  });
+
+  it('should initialize available columns based on definition and allColumns', () => {
+    const clearFilterValueSpy = jest.spyOn(component, 'clearFilterValue');
+    component.ngOnInit();
+    expect(component.selectedColumns).toEqual([]);
+    expect(component.availableColumns).toEqual([
+      { id: '1', label: 'Test Column 1', dataPropertyName: 'test1' },
+      { id: '2', label: 'Test Column 2', dataPropertyName: 'test2' },
+    ]);
+    expect(component.filteredAvailableColumns).toEqual([
+      { id: '1', label: 'Test Column 1', dataPropertyName: 'test1' },
+      { id: '2', label: 'Test Column 2', dataPropertyName: 'test2' },
+    ]);
+    expect(clearFilterValueSpy).toHaveBeenCalled();
+  });
+
+  it('should initialize selected columns based on definition and allColumns', () => {
+    const clearFilterValueSpy = jest.spyOn(component, 'clearFilterValue');
+    dialogDataMock.definition =  { displayedColumns: [{ id: '1', label: 'Test Column 1', dataPropertyName: 'test1' }], id: '1', label: 'firstDefinition' };
+    component.ngOnInit();
+    expect(component.selectedColumns).toEqual([{ id: '1', label: 'Test Column 1', dataPropertyName: 'test1' }]);
+    expect(component.availableColumns).toEqual([{ id: '2', label: 'Test Column 2', dataPropertyName: 'test2' }]);
+    expect(component.filteredAvailableColumns).toEqual(component.availableColumns);
+    expect(clearFilterValueSpy).toHaveBeenCalled();
+  });
+
+  it('should be able to handle drag and drop', () => {
+    const previousContainerData: DataTableColumn[] = [
+      { id: '2', label: 'Test Column 2', dataPropertyName: 'test2' },
+      { id: '3', label: 'Test Column 3', dataPropertyName: 'test3' },
+    ];
+    const containerData: DataTableColumn[] = [];
+    const event: any = {
+      previousContainer: { data: [...previousContainerData] },
+      container: { data: containerData },
+      currentIndex: 1,
+      item: {
+        element: {
+          nativeElement: { id: '2' },
+        },
+      },
+    };
+    const clearFilterValueSpy = jest.spyOn(component, 'clearFilterValue');
+    component.onDrop(event as CdkDragDrop<DataTableColumn[]>);
+
+    expect(event.previousContainer.data).toEqual([previousContainerData[1]]);
+    expect(event.container.data).toEqual([previousContainerData[0]]);
+    expect(clearFilterValueSpy).toHaveBeenCalled();
+  });
+
+  it('should be able to handle drag and drop with equal containers', () => {
+    const containerData: any = {
+      data: [
+        { id: '2', label: 'Test Column 2', dataPropertyName: 'test2' },
+        { id: '3', label: 'Test Column 3', dataPropertyName: 'test3' },
+      ],
+    };
+    const event: any = {
+      previousContainer: containerData,
+      container: containerData,
+      currentIndex: 0,
+      previousIndex: 1,
+      item: {
+        element: {
+          nativeElement: { id: '2' },
+        },
+      },
+    };
+    const clearFilterValueSpy = jest.spyOn(component, 'clearFilterValue');
+    component.onDrop(event as CdkDragDrop<DataTableColumn[]>);
+    expect(event.container.data).toEqual([
+      { id: '3', label: 'Test Column 3', dataPropertyName: 'test3' },
+      { id: '2', label: 'Test Column 2', dataPropertyName: 'test2' },
+    ]);
+    expect(clearFilterValueSpy).not.toHaveBeenCalled();
+  });
+
+  it('should be able to close dialog with data on save', () => {
+    component.ngOnInit();
+    component.onSave();
+    expect(dialogRefMock.close).toHaveBeenCalledWith({
+      action: 'SAVE',
+      definition: component.definition,
+    });
+  });
+
+  it('should be able to close dialog with data on delete', () => {
+    component.onDelete();
+    expect(dialogRefMock.close).toHaveBeenCalledWith({
+      action: 'DELETE',
+      definition: component.definition,
+    });
+  });
+
+  it('should be able to just close dialog onCancel', () => {
+    component.onCancel();
+    expect(dialogRefMock.close).toHaveBeenCalled();
+  });
+
+  it('should filter available columns when updateFilterValue is called', () => {
+    component.ngOnInit();
+    component.searchFilter = 'Test Column 1';
+    component.updateFilterValue();
+    expect(component.filteredAvailableColumns).toEqual([{ id: '1', label: 'Test Column 1', dataPropertyName: 'test1' }]);
+  });
+
+  it('should return available columns when updateFilterValue is called with empty filter', () => {
+    component.ngOnInit();
+    component.searchFilter = '';
+    component.updateFilterValue();
+    expect(component.filteredAvailableColumns).toEqual(component.availableColumns);
+  });
+
+  it('should clear the filter and reset filtered available columns', () => {
+    component.clearFilterValue();
+    expect(component.searchFilter).toBe('');
+    expect(component.filteredAvailableColumns).toEqual(component.availableColumns);
+  });
+});

--- a/projects/material-addons/src/lib/data-table/data-table.component.spec.ts
+++ b/projects/material-addons/src/lib/data-table/data-table.component.spec.ts
@@ -19,7 +19,7 @@ import { DataTableColumnsModalComponent } from './data-table-columns-modal/data-
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ButtonModule } from '../button/button.module';
 import { of } from 'rxjs';
-import {DataTableActionType} from './data-table-action-type';
+import { DataTableActionType } from './data-table-action-type';
 
 const mockDataTableAction: DataTableAction = {
   label: 'Test Label',
@@ -212,7 +212,7 @@ describe('DataTableComponent', () => {
   describe('onSortingEvent', () => {
     it('should emit sortEvent when onSortingEvent is called and useAsync is true', () => {
       component.useAsync = true;
-      const expectedSort: Sort = {active: 'name', direction: 'desc'};
+      const expectedSort: Sort = { active: 'name', direction: 'desc' };
       jest.spyOn(component.sortEvent, 'emit');
       component.onSortingEvent(expectedSort);
 
@@ -223,17 +223,17 @@ describe('DataTableComponent', () => {
     it('should sort data internally when onSortingEvent is called and useAsync is false', () => {
       component.useAsync = false;
       const initialData: any[] = [
-        {id: 1, name: 'Zebra'},
-        {id: 2, name: 'Alligator'},
-        {id: 3, name: 'Moose'},
+        { id: 1, name: 'Zebra' },
+        { id: 2, name: 'Alligator' },
+        { id: 3, name: 'Moose' },
       ];
       const expectedData: any[] = [
-        {id: 2, name: 'Alligator'},
-        {id: 3, name: 'Moose'},
-        {id: 1, name: 'Zebra'},
+        { id: 2, name: 'Alligator' },
+        { id: 3, name: 'Moose' },
+        { id: 1, name: 'Zebra' },
       ];
       component.dataSource = new MatTableDataSource(initialData);
-      const sortEvent: Sort = {active: 'name', direction: 'asc'};
+      const sortEvent: Sort = { active: 'name', direction: 'asc' };
       component.onSortingEvent(sortEvent);
 
       expect(component.dataSource.data).toEqual(expectedData);
@@ -246,8 +246,8 @@ describe('DataTableComponent', () => {
   describe('actionEvent', () => {
     it('should emit actionEvent when onTableAction is called with a tableAction', () => {
       const mockRowMap = new Map<string, DataTableRow>();
-      const row1: DataTableRow = {id: '1', actualData: {id: '1', name: 'Test1'}, displayedData: null};
-      const row2: DataTableRow = {id: '2', actualData: {id: '2', name: 'Test2'}, displayedData: null};
+      const row1: DataTableRow = { id: '1', actualData: { id: '1', name: 'Test1' }, displayedData: null };
+      const row2: DataTableRow = { id: '2', actualData: { id: '2', name: 'Test2' }, displayedData: null };
       mockRowMap.set('1', row1);
       mockRowMap.set('2', row2);
       component.rowMap = mockRowMap;
@@ -268,8 +268,8 @@ describe('DataTableComponent', () => {
 
     it('should emit actionEvent when onTableAction is called with a tableAction and idGenerator is a function', () => {
       const mockSelected = [
-        {id: '1', name: 'Test1'},
-        {id: '2', name: 'Test2'},
+        { id: '1', name: 'Test1' },
+        { id: '2', name: 'Test2' },
       ];
       component.selectionModel = {
         selected: mockSelected,
@@ -311,8 +311,8 @@ describe('DataTableComponent', () => {
     it('should emit actionEvent with actualData when "SINGLE" mode is selected', () => {
       component.mode = DataTableActionType.SINGLE;
       const mockRowMap = new Map<string, DataTableRow>();
-      const row1: DataTableRow = {id: '1', actualData: {id: '1', name: 'Test1'}, displayedData: null};
-      const row2: DataTableRow = {id: '2', actualData: {id: '2', name: 'Test2'}, displayedData: null};
+      const row1: DataTableRow = { id: '1', actualData: { id: '1', name: 'Test1' }, displayedData: null };
+      const row2: DataTableRow = { id: '2', actualData: { id: '2', name: 'Test2' }, displayedData: null };
       mockRowMap.set('1', row1);
       mockRowMap.set('2', row2);
       component.rowMap = mockRowMap;
@@ -381,7 +381,7 @@ describe('DataTableComponent', () => {
     component.allColumns = exampleColumns;
     const mockCloseModalResult: DataTableColumnDefinitionChange = {
       action: 'SAVE',
-      definition: columnDefinitions[0]
+      definition: columnDefinitions[0],
     };
     const mockDialogRef = { afterClosed: jest.fn().mockReturnValue(of(mockCloseModalResult)) };
     jest.spyOn((component as any).matDialog, 'open').mockReturnValue(mockDialogRef as any);
@@ -470,9 +470,9 @@ describe('DataTableComponent', () => {
   describe('onToggleSelectAll method', () => {
     it('should clear selectionModel, toggle allSelected and select all rows when allSelected is false', () => {
       const initialData: any[] = [
-        {rowId: 1, id: 1, name: 'Zebra'},
-        {rowId: 2, id: 2, name: 'Alligator'},
-        {rowId: 3, name: 'Moose'},
+        { rowId: 1, id: 1, name: 'Zebra' },
+        { rowId: 2, id: 2, name: 'Alligator' },
+        { rowId: 3, name: 'Moose' },
       ];
       component.dataSource = new MatTableDataSource(initialData);
       component.allSelected = false;
@@ -491,9 +491,9 @@ describe('DataTableComponent', () => {
 
     it('should clear selectionModel, toggle allSelected to false and selection should be empty', () => {
       const initialData: any[] = [
-        {rowId: 1, id: 1, name: 'Zebra'},
-        {rowId: 2, id: 2, name: 'Alligator'},
-        {rowId: 3, name: 'Moose'},
+        { rowId: 1, id: 1, name: 'Zebra' },
+        { rowId: 2, id: 2, name: 'Alligator' },
+        { rowId: 3, name: 'Moose' },
       ];
       component.dataSource = new MatTableDataSource(initialData);
       component.allSelected = true;
@@ -645,8 +645,7 @@ describe('DataTableComponent', () => {
 
       expect(component.selectedColumnDefinion).toEqual(def);
       expect(component.columns).toEqual(def.displayedColumns);
-      expect(component.columnIds).toEqual([component.ACTION_COLUMN_NAME]
-        .concat(def.displayedColumns.map((column) => column.id)));
+      expect(component.columnIds).toEqual([component.ACTION_COLUMN_NAME].concat(def.displayedColumns.map((column) => column.id)));
     });
 
     it('should set paginatorPageIndex, paginatorPageSize, and paginatorLength when page is set', () => {

--- a/projects/material-addons/src/lib/data-table/data-table.component.spec.ts
+++ b/projects/material-addons/src/lib/data-table/data-table.component.spec.ts
@@ -1,0 +1,749 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DataTableComponent } from './data-table.component';
+import { MatMenuModule } from '@angular/material/menu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatPaginator, MatPaginatorIntl, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
+import { exampleData } from '../../../../../src/app/example-components/data-table-example-data/data-table-example-data';
+import { exampleColumns } from '../../../../../src/app/example-components/data-table-example-data/data-table-example-columns';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatInputModule } from '@angular/material/input';
+import { ChangeDetectorRef } from '@angular/core';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { SelectionModel } from '@angular/cdk/collections';
+import { DataTableAction } from './data-table-action';
+import { DataTableRow } from './data-table-row';
+import { DataTableColumnDefinition, DataTableColumnDefinitionChange } from './data-table-column-definition';
+import { DataTableColumnsModalComponent } from './data-table-columns-modal/data-table-columns-modal.component';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { ButtonModule } from '../button/button.module';
+import { of } from 'rxjs';
+import {DataTableActionType} from './data-table-action-type';
+
+const mockDataTableAction: DataTableAction = {
+  label: 'Test Label',
+  action: 'Test Action',
+  type: 'SINGLE',
+};
+
+const mockPageEvent: PageEvent = {
+  length: 100,
+  pageIndex: 1,
+  pageSize: 10,
+} as PageEvent;
+
+const actionsMock: DataTableAction[] = [
+  {
+    label: 'Edit',
+    action: 'EDIT',
+    type: 'SINGLE',
+  },
+  {
+    label: 'Delete',
+    action: 'DELETE',
+    type: 'SINGLE',
+  },
+  {
+    label: 'Create',
+    action: 'CREATE',
+    type: 'NONE',
+  },
+  {
+    label: 'Batch',
+    action: 'BATCH',
+    type: 'BATCH',
+    hiddenInMode: '',
+  },
+];
+
+const columnDefinitions: DataTableColumnDefinition[] = [
+  {
+    id: '12345678-default',
+    label: 'Default',
+    displayedColumns: exampleColumns,
+  },
+  {
+    id: '87654321-company',
+    label: 'Settings 1',
+    editable: true,
+    displayedColumns: [
+      {
+        id: '0002-Name',
+        label: 'Name',
+        isSortable: true,
+        orderByName: 'name',
+        dataPropertyName: 'name',
+      },
+      {
+        id: '0005-Salary',
+        label: 'Salary',
+        orderByName: 'salary',
+        dataPropertyName: 'salary',
+        isRightAligned: true,
+        isSortable: true,
+      },
+      {
+        id: '0003-Gender',
+        label: 'Gender',
+        orderByName: 'gender',
+        dataPropertyName: 'gender',
+      },
+      {
+        id: '0001-Title',
+        label: 'Title',
+        isSortable: true,
+        orderByName: 'title',
+        dataPropertyName: 'title',
+      },
+    ],
+  },
+  {
+    id: 'user-123',
+    label: 'Other settings',
+    editable: true,
+    displayedColumns: [
+      {
+        id: '0006-Email',
+        label: 'Email',
+        orderByName: 'email',
+        dataPropertyName: 'email',
+      },
+      {
+        id: '0002-Name',
+        label: 'Name',
+        isSortable: true,
+        orderByName: 'name',
+        dataPropertyName: 'name',
+      },
+    ],
+  },
+];
+
+describe('DataTableComponent', () => {
+  let component: DataTableComponent;
+  let fixture: ComponentFixture<DataTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DataTableComponent, DataTableColumnsModalComponent],
+      imports: [
+        MatTableModule,
+        MatMenuModule,
+        NoopAnimationsModule,
+        MatPaginatorModule,
+        MatSortModule,
+        MatInputModule,
+        ButtonModule,
+        MatFormFieldModule,
+        TranslateModule.forRoot(),
+        DragDropModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DataTableComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create DataTableComponent', () => {
+    component.tableData = exampleData;
+    component.displayedColumns = exampleColumns;
+    component.paginationEnabled = true;
+    component.filterEnabled = true;
+
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should create data source', () => {
+    component.displayedColumns = exampleColumns;
+    component.paginationEnabled = true;
+    component.filterEnabled = true;
+    component.paginator = new MatPaginator(new MatPaginatorIntl(), ChangeDetectorRef.prototype);
+    component.sort = new MatSort();
+    component.tableData = exampleData;
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+    expect(component.dataSource).toBeDefined();
+    expect(component.dataSource.data.length).toEqual(exampleData.length);
+  });
+
+  it('should create component in BATCH mode, because actions contains BATCH action', () => {
+    component.actions = actionsMock;
+    component._forceMode = '';
+    component.ngOnInit();
+
+    expect(component.mode).toEqual(DataTableActionType.BATCH);
+    expect(component.isRowClickable).toEqual(true);
+    expect(component.defaultAction).toBeUndefined();
+  });
+
+  it('should create component in SINGLE mode, because actions contains SINGLE action', () => {
+    component.actions = [mockDataTableAction];
+    component._forceMode = '';
+    component.ngOnInit();
+
+    expect(component.mode).toEqual(DataTableActionType.SINGLE);
+    expect(component.isRowClickable).toBeTruthy();
+    expect(component.defaultAction).toEqual(mockDataTableAction);
+  });
+
+  it('should create component in NONE mode, because actions are empty', () => {
+    component._forceMode = '';
+    component.ngOnInit();
+
+    expect(component.mode).toEqual(DataTableActionType.NONE);
+    expect(component.isRowClickable).toBeFalsy();
+    expect(component.defaultAction).toBeUndefined();
+  });
+
+  it('should create component with provided force mode (ex SINGLE)', () => {
+    component._forceMode = DataTableActionType.SINGLE;
+    component.ngOnInit();
+
+    expect(component.mode).toEqual(DataTableActionType.SINGLE);
+    expect(component.isRowClickable).toBeTruthy();
+    expect(component.defaultAction).toBeUndefined();
+  });
+
+  describe('onSortingEvent', () => {
+    it('should emit sortEvent when onSortingEvent is called and useAsync is true', () => {
+      component.useAsync = true;
+      const expectedSort: Sort = {active: 'name', direction: 'desc'};
+      jest.spyOn(component.sortEvent, 'emit');
+      component.onSortingEvent(expectedSort);
+
+      expect(component.sortEvent.emit).toHaveBeenCalledTimes(1);
+      expect(component.sortEvent.emit).toHaveBeenCalledWith(expectedSort);
+    });
+
+    it('should sort data internally when onSortingEvent is called and useAsync is false', () => {
+      component.useAsync = false;
+      const initialData: any[] = [
+        {id: 1, name: 'Zebra'},
+        {id: 2, name: 'Alligator'},
+        {id: 3, name: 'Moose'},
+      ];
+      const expectedData: any[] = [
+        {id: 2, name: 'Alligator'},
+        {id: 3, name: 'Moose'},
+        {id: 1, name: 'Zebra'},
+      ];
+      component.dataSource = new MatTableDataSource(initialData);
+      const sortEvent: Sort = {active: 'name', direction: 'asc'};
+      component.onSortingEvent(sortEvent);
+
+      expect(component.dataSource.data).toEqual(expectedData);
+      expect(component.dataSource.data).not.toEqual(initialData);
+    });
+
+    // add sorting by dates after upgrade
+  });
+
+  describe('actionEvent', () => {
+    it('should emit actionEvent when onTableAction is called with a tableAction', () => {
+      const mockRowMap = new Map<string, DataTableRow>();
+      const row1: DataTableRow = {id: '1', actualData: {id: '1', name: 'Test1'}, displayedData: null};
+      const row2: DataTableRow = {id: '2', actualData: {id: '2', name: 'Test2'}, displayedData: null};
+      mockRowMap.set('1', row1);
+      mockRowMap.set('2', row2);
+      component.rowMap = mockRowMap;
+      const mockSelected = ['1', '2'];
+      component.selectionModel = {
+        selected: mockSelected,
+      } as SelectionModel<any>;
+      const fakeDataTableAction: DataTableAction = mockDataTableAction;
+      jest.spyOn(component.actionEvent, 'emit');
+      component.onTableAction(fakeDataTableAction);
+
+      expect(component.actionEvent.emit).toHaveBeenCalledTimes(1);
+      expect(component.actionEvent.emit).toHaveBeenCalledWith({
+        ...fakeDataTableAction,
+        selected: [row1.actualData, row2.actualData],
+      });
+    });
+
+    it('should emit actionEvent when onTableAction is called with a tableAction and idGenerator is a function', () => {
+      const mockSelected = [
+        {id: '1', name: 'Test1'},
+        {id: '2', name: 'Test2'},
+      ];
+      component.selectionModel = {
+        selected: mockSelected,
+      } as SelectionModel<any>;
+      component.idGenerator = (data: any) => data.id + '_generated';
+      const fakeDataTableAction: DataTableAction = mockDataTableAction;
+      jest.spyOn(component.actionEvent, 'emit');
+      component.onTableAction(fakeDataTableAction);
+
+      expect(component.actionEvent.emit).toHaveBeenCalledTimes(1);
+      expect(component.actionEvent.emit).toHaveBeenCalledWith({
+        ...fakeDataTableAction,
+      });
+    });
+
+    const mockRow: { rowId: string; parentId?: string } = {
+      rowId: '1',
+    };
+
+    it('should not emit actionEvent when "BATCH" mode is selected', () => {
+      component.mode = DataTableActionType.BATCH;
+      jest.spyOn(component.selectionModel, 'toggle');
+      jest.spyOn(component.actionEvent, 'emit');
+      component.onRowEvent(new MouseEvent('click'), mockRow, mockDataTableAction);
+
+      expect(component.selectionModel.toggle).toHaveBeenCalledTimes(1);
+      expect(component.selectionModel.toggle).toHaveBeenCalledWith(mockRow.rowId);
+      expect(component.actionEvent.emit).not.toHaveBeenCalled();
+    });
+
+    it('should not emit actionEvent when "NONE" mode is selected', () => {
+      component.mode = DataTableActionType.NONE;
+      const actionEventSpy = jest.spyOn(component.actionEvent, 'emit');
+      component.onRowEvent(new MouseEvent('click'), mockRow, mockDataTableAction);
+
+      expect(actionEventSpy).not.toHaveBeenCalled();
+    });
+
+    it('should emit actionEvent with actualData when "SINGLE" mode is selected', () => {
+      component.mode = DataTableActionType.SINGLE;
+      const mockRowMap = new Map<string, DataTableRow>();
+      const row1: DataTableRow = {id: '1', actualData: {id: '1', name: 'Test1'}, displayedData: null};
+      const row2: DataTableRow = {id: '2', actualData: {id: '2', name: 'Test2'}, displayedData: null};
+      mockRowMap.set('1', row1);
+      mockRowMap.set('2', row2);
+      component.rowMap = mockRowMap;
+      jest.spyOn(component.actionEvent, 'emit');
+      component.onRowEvent(new MouseEvent('click'), mockRow, mockDataTableAction);
+
+      expect(component.actionEvent.emit).toHaveBeenCalledTimes(1);
+      expect(component.actionEvent.emit).toHaveBeenCalledWith({
+        ...mockDataTableAction,
+        selected: [row1.actualData],
+      });
+    });
+  });
+
+  it('should emit pageEvent when useAsync is true', () => {
+    component.useAsync = true;
+    jest.spyOn(component.pageEvent, 'emit');
+    component.onPageEvent(mockPageEvent);
+
+    expect(component.pageEvent.emit).toHaveBeenCalledTimes(1);
+    expect(component.pageEvent.emit).toHaveBeenCalledWith(mockPageEvent);
+  });
+
+  it('should not emit pageEvent when useAsync is false', () => {
+    component.useAsync = false;
+    jest.spyOn(component.pageEvent, 'emit');
+    component.onPageEvent(mockPageEvent);
+
+    expect(component.pageEvent.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit allColumnsEvent when columnDefinition is not provided', () => {
+    jest.spyOn(component.allColumnsEvent, 'emit');
+    component.onColumnSettings();
+
+    expect(component.showColumnModal).toBeTruthy();
+    expect(component.selectedDefinition).toBeUndefined();
+    expect(component.allColumnsEvent.emit).toHaveBeenCalledTimes(1);
+  });
+
+  //check checkboxes and check selectionModel
+
+  it('should emit allColumnsEvent when columnDefinition is provided', () => {
+    component.columnDefinitions = columnDefinitions;
+    jest.spyOn(component.allColumnsEvent, 'emit');
+    component.onColumnSettings();
+
+    expect(component.showColumnModal).toBeTruthy();
+    expect(component.selectedDefinition).not.toBeNull();
+    expect(component.selectedDefinition).toEqual(columnDefinitions[0]);
+    expect(component.allColumnsEvent.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit allColumnsEvent when allColumns is provided', () => {
+    component.allColumns = exampleColumns;
+    jest.spyOn(component.allColumnsEvent, 'emit');
+    component.onColumnSettings();
+
+    expect(component.showColumnModal).toBeTruthy();
+    expect(component.selectedDefinition).toBeUndefined();
+    expect(component.allColumnsEvent.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit columnDefinitionChangeEvent when dialog closed with result', () => {
+    component.columnDefinitions = columnDefinitions;
+    component.allColumns = exampleColumns;
+    const mockCloseModalResult: DataTableColumnDefinitionChange = {
+      action: 'SAVE',
+      definition: columnDefinitions[0]
+    };
+    const mockDialogRef = { afterClosed: jest.fn().mockReturnValue(of(mockCloseModalResult)) };
+    jest.spyOn((component as any).matDialog, 'open').mockReturnValue(mockDialogRef as any);
+    const emitSpy = jest.spyOn(component.columnDefinitionChangeEvent, 'emit');
+    component.onColumnSettings(); //calls openColumnModal
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith(mockCloseModalResult);
+  });
+
+  it('should emit viewDefinitionChangeEvent when onViewDefinition is called', () => {
+    component.columnDefinitions = columnDefinitions;
+    const emitSpy = jest.spyOn(component.viewDefinitionChangeEvent, 'emit');
+    component.onViewDefinition(component.viewableColumnDefinitions[0]);
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith(component.viewableColumnDefinitions[0]);
+  });
+
+  it('should call setFilterValue when a filterValue is set and dataSource provided', () => {
+    const initialData: any[] = [
+      { id: 1, name: 'Zebra' },
+      { id: 2, name: 'Alligator' },
+      { id: 3, name: 'Moose' },
+    ];
+    const expectedData: any[] = [{ id: 2, name: 'Alligator' }];
+    component.dataSource = new MatTableDataSource(initialData);
+    const setFilterValueSpy = jest.spyOn(component, 'setFilterValue');
+    component.filterValue = 'Alli';
+
+    expect(setFilterValueSpy).toHaveBeenCalledTimes(1);
+    expect(setFilterValueSpy).toHaveBeenCalledWith('Alli');
+    expect(component.dataSource.filter).toEqual('alli');
+    expect(component.dataSource.filteredData).toEqual(expectedData);
+  });
+
+  it('should call setFilterValue when a filterValue is set and dataSource not provided', () => {
+    const setFilterValueSpy = jest.spyOn(component, 'setFilterValue');
+    component.filterValue = 'Alli';
+
+    expect(setFilterValueSpy).not.toHaveBeenCalled();
+  });
+
+  it('should set forceMode without actions, call selectionModel clear and actions should be empty', () => {
+    const modes = [DataTableActionType.SINGLE, DataTableActionType.BATCH, DataTableActionType.NONE];
+    modes.forEach((mode) => {
+      const selectionModelClearSpy = jest.spyOn(component.selectionModel, 'clear');
+      component.forceMode = mode;
+
+      expect(component._forceMode).toEqual(mode);
+      expect(component.mode).toEqual(mode);
+      expect(selectionModelClearSpy).toHaveBeenCalled();
+      expect(component.rowActions).toHaveLength(0);
+      expect(component.tableActions).toHaveLength(0);
+    });
+  });
+
+  it('should contain correct table/row actions if set forceMode with actions', () => {
+    const modes = [DataTableActionType.SINGLE, DataTableActionType.BATCH, DataTableActionType.NONE];
+    component.actions = actionsMock;
+    modes.forEach((mode) => {
+      const selectionModelClearSpy = jest.spyOn(component.selectionModel, 'clear');
+      component.forceMode = mode;
+
+      expect(component._forceMode).toEqual(mode);
+      expect(component.mode).toEqual(mode);
+      expect(selectionModelClearSpy).toHaveBeenCalled();
+
+      switch (mode) {
+        case DataTableActionType.SINGLE:
+          expect(component.rowActions).toHaveLength(2);
+          expect(component.tableActions).toHaveLength(1);
+          break;
+        case DataTableActionType.BATCH:
+          expect(component.rowActions).toHaveLength(0);
+          expect(component.tableActions).toHaveLength(4);
+          break;
+        case DataTableActionType.NONE:
+          expect(component.rowActions).toHaveLength(0);
+          expect(component.tableActions).toHaveLength(4);
+          break;
+      }
+    });
+  });
+
+  describe('onToggleSelectAll method', () => {
+    it('should clear selectionModel, toggle allSelected and select all rows when allSelected is false', () => {
+      const initialData: any[] = [
+        {rowId: 1, id: 1, name: 'Zebra'},
+        {rowId: 2, id: 2, name: 'Alligator'},
+        {rowId: 3, name: 'Moose'},
+      ];
+      component.dataSource = new MatTableDataSource(initialData);
+      component.allSelected = false;
+      const clearSpy = jest.spyOn(component.selectionModel, 'clear');
+      const selectSpy = jest.spyOn(component.selectionModel, 'select');
+      const getAllDataSourceRowsOfCurrentPageSpy = jest.spyOn(component, 'getAllDataSourceRowsOfCurrentPage');
+      component.onToggleSelectAll();
+
+      expect(clearSpy).toHaveBeenCalled();
+      expect(component.allSelected).toBeTruthy();
+      expect(getAllDataSourceRowsOfCurrentPageSpy).toHaveBeenCalledTimes(1);
+      expect(getAllDataSourceRowsOfCurrentPageSpy).toHaveReturnedWith(component.dataSource.data);
+      expect(selectSpy).toHaveBeenNthCalledWith(1, '1');
+      expect(selectSpy).toHaveBeenNthCalledWith(2, '2');
+    });
+
+    it('should clear selectionModel, toggle allSelected to false and selection should be empty', () => {
+      const initialData: any[] = [
+        {rowId: 1, id: 1, name: 'Zebra'},
+        {rowId: 2, id: 2, name: 'Alligator'},
+        {rowId: 3, name: 'Moose'},
+      ];
+      component.dataSource = new MatTableDataSource(initialData);
+      component.allSelected = true;
+      const clearSpy = jest.spyOn(component.selectionModel, 'clear');
+      const selectSpy = jest.spyOn(component.selectionModel, 'select');
+      const getAllDataSourceRowsOfCurrentPageSpy = jest.spyOn(component, 'getAllDataSourceRowsOfCurrentPage');
+      component.onToggleSelectAll();
+
+      expect(clearSpy).toHaveBeenCalled();
+      expect(component.allSelected).toBeFalsy();
+      expect(getAllDataSourceRowsOfCurrentPageSpy).not.toHaveBeenCalled();
+      expect(selectSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSelectedCount method', () => {
+    it('should return empty string if actionType is not BATCH', () => {
+      const actionType = DataTableActionType.SINGLE;
+      const result = component.getSelectedCount(actionType);
+      expect(result).toEqual('');
+    });
+
+    it('should return empty string if count is less than 2', () => {
+      const actionType = DataTableActionType.BATCH;
+      component.selectionModel.select('1');
+      const result = component.getSelectedCount(actionType);
+
+      expect(result).toEqual('');
+    });
+
+    it('should return string with count if actionType is BATCH and count is 2 or more', () => {
+      const actionType = DataTableActionType.BATCH;
+      component.selectionModel.select('1', '2');
+      const expectedOutput = ` (2)`; // output string has a leading space
+      const result = component.getSelectedCount(actionType);
+
+      expect(result).toEqual(expectedOutput);
+    });
+
+    it('should handle case when selectionModel is null or undefined', () => {
+      const actionType = DataTableActionType.BATCH;
+      component.selectionModel = null;
+      const result = component.getSelectedCount(actionType);
+
+      expect(result).toEqual('');
+    });
+  });
+
+  describe('isSelected method', () => {
+    beforeEach(() => {
+      // reset selection before each test
+      component.selectionModel.clear();
+    });
+
+    it.each([
+      { rowId: '1', selectedRowIds: ['1', '2'], expectedIsSelected: true },
+      { rowId: '2', selectedRowIds: ['1'], expectedIsSelected: false },
+    ])(
+      'for rowId $rowId, isSelected should return $expectedIsSelected when these rowIds are selected $selectedRowIds',
+      ({ rowId, selectedRowIds, expectedIsSelected }) => {
+        component.selectionModel.select(...selectedRowIds);
+        const isSelectedSpy = jest.spyOn(component.selectionModel, 'isSelected');
+        const result = component.isSelected(rowId);
+
+        expect(result).toBe(expectedIsSelected);
+        expect(isSelectedSpy).toHaveBeenCalledTimes(1);
+        expect(isSelectedSpy).toHaveBeenCalledWith(rowId);
+      },
+    );
+  });
+
+  describe('isDisabled method', () => {
+    const tests = [
+      {
+        description: 'should return true if actionType is SINGLE and selectedCount is not 1',
+        actionType: 'SINGLE',
+        selectedItems: ['1', '2'],
+        expected: true,
+      },
+      {
+        description: 'should return false if actionType is SINGLE and selectedCount is 1',
+        actionType: 'SINGLE',
+        selectedItems: ['1'],
+        expected: false,
+      },
+      {
+        description: 'should return true if actionType is BATCH and selectedCount is 0',
+        actionType: 'BATCH',
+        selectedItems: [],
+        expected: true,
+      },
+      {
+        description: 'should return false if actionType is BATCH and selectedCount is 1 or more',
+        actionType: 'BATCH',
+        selectedItems: ['1'],
+        expected: false,
+      },
+      {
+        description: 'should return false if actionType is not SINGLE or BATCH',
+        actionType: 'NONE',
+        selectedItems: ['1', '2'],
+        expected: false,
+      },
+    ];
+
+    tests.forEach(({ description, actionType, selectedItems, expected }) => {
+      it(description, () => {
+        component.selectionModel.clear();
+        component.selectionModel.select(...selectedItems);
+        const isDisabled = component.isDisabled(actionType);
+
+        expect(isDisabled).toEqual(expected);
+      });
+    });
+  });
+
+  describe('Simple component property bindings', () => {
+    it('should set isLoading when loading Input property is set', () => {
+      const isLoadingValue = true;
+      component.loading = isLoadingValue;
+
+      expect(component.isLoading).toEqual(isLoadingValue);
+    });
+
+    it('should set paginatorPageSize when defaultPageSize Input property is set', () => {
+      const defaultSizeValue = 10;
+      component.defaultPageSize = defaultSizeValue;
+
+      expect(component.paginatorPageSize).toEqual(defaultSizeValue);
+    });
+
+    it('should set extPaginator when externalPaginator Input property is set', () => {
+      const paginatorValue = { pageIndex: 1, pageSize: 10 };
+      component.externalPaginator = paginatorValue;
+
+      expect(component.extPaginator).toEqual(paginatorValue);
+    });
+
+    it('should set extPaginator when externalPaginator Input property is set', () => {
+      const paginatorValue = { pageIndex: 1, pageSize: 10 };
+      component.externalPaginator = paginatorValue;
+
+      expect(component.extPaginator).toEqual(paginatorValue);
+    });
+
+    it('displayedColumnDefinition should populate selectedColumnDefinition, columns, and columnIds with additional action column', () => {
+      const def: DataTableColumnDefinition = columnDefinitions[0];
+      component.displayedColumnDefinition = def;
+
+      expect(component.selectedColumnDefinion).toEqual(def);
+      expect(component.columns).toEqual(def.displayedColumns);
+      expect(component.columnIds).toEqual([component.ACTION_COLUMN_NAME]
+        .concat(def.displayedColumns.map((column) => column.id)));
+    });
+
+    it('should set paginatorPageIndex, paginatorPageSize, and paginatorLength when page is set', () => {
+      component.page = mockPageEvent;
+
+      expect(component.paginatorPageIndex).toEqual(mockPageEvent.pageIndex);
+      expect(component.paginatorPageSize).toEqual(mockPageEvent.pageSize);
+      expect(component.paginatorLength).toEqual(mockPageEvent.length);
+    });
+  });
+
+  describe('isCurrentDefinition', () => {
+    it('should return true if the selected definition id matches the provided definition id', () => {
+      const definition = columnDefinitions[0];
+      component.selectedDefinition = columnDefinitions[0];
+
+      expect(component.isCurrentDefinition(definition)).toBeTruthy();
+    });
+
+    it('should return false if the selected definition id does not match the provided definition id', () => {
+      const definition = columnDefinitions[0];
+      component.selectedDefinition = columnDefinitions[2];
+
+      expect(component.isCurrentDefinition(definition)).toBeFalsy();
+    });
+
+    it('should return false if no selected definition is set', () => {
+      const definition = columnDefinitions[0];
+      component.selectedDefinition = null;
+
+      expect(component.isCurrentDefinition(definition)).toBeFalsy();
+    });
+  });
+
+  describe('DataTableComponent static methods', () => {
+    it('should compare number types correctly', () => {
+      const a = { sortKey: 5 };
+      const b = { sortKey: 12 };
+      const ascSort: Sort = { active: 'sortKey', direction: 'asc' };
+      const descSort: Sort = { active: 'sortKey', direction: 'desc' };
+
+      expect(DataTableComponent.compare(a, b, ascSort)).toBeLessThan(0);
+      expect(DataTableComponent.compare(a, b, descSort)).toBeGreaterThan(0);
+    });
+
+    it('should compare string types correctly', () => {
+      const a = { sortKey: 'apple' };
+      const b = { sortKey: 'banana' };
+      const ascSort: Sort = { active: 'sortKey', direction: 'asc' };
+      const descSort: Sort = { active: 'sortKey', direction: 'desc' };
+
+      expect(DataTableComponent.compare(a, b, ascSort)).toBeLessThan(0);
+      expect(DataTableComponent.compare(a, b, descSort)).toBeGreaterThan(0);
+    });
+
+    it('should compare boolean types correctly', () => {
+      const a = { sortKey: false };
+      const b = { sortKey: true };
+      const c = { sortKey: true };
+      const ascSort: Sort = { active: 'sortKey', direction: 'asc' };
+      const descSort: Sort = { active: 'sortKey', direction: 'desc' };
+
+      expect(DataTableComponent.compare(a, b, ascSort)).toBeGreaterThan(0);
+      expect(DataTableComponent.compare(a, b, descSort)).toBeLessThan(0);
+      expect(DataTableComponent.compare(b, c, descSort)).toEqual(0);
+    });
+
+    it('should return 0 if value types are not number, string, or boolean', () => {
+      const a = { sortKey: {} };
+      const b = { sortKey: {} };
+      const sort: Sort = { active: 'sortKey', direction: 'asc' };
+
+      expect(DataTableComponent.compare(a, b, sort)).toEqual(0);
+    });
+  });
+
+  describe('DataTableComponent transformData method', () => {
+    it('should return original value if no transformer provided', () => {
+      const value = 'Test Value';
+
+      expect(DataTableComponent.transformData(value, null, null)).toEqual(value);
+    });
+
+    it('should return original value if transformer is not a function', () => {
+      const value = 'Test Value';
+      const transformer = 'Not a function';
+
+      expect(DataTableComponent.transformData(value, transformer, null)).toEqual(value);
+    });
+
+    it('should correctly transform value with transformer function', () => {
+      const value = 'Test Value';
+      const transformer = (v: string, p: any) => `${v} Transformed With ${p}`;
+      const transformerParams = 'Params';
+
+      const expectedResult = 'Test Value Transformed With Params';
+      expect(DataTableComponent.transformData(value, transformer, transformerParams)).toEqual(expectedResult);
+    });
+  });
+});

--- a/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
@@ -1,6 +1,6 @@
-import {FormatOptions, NumberFormatService, StripOptions} from './number-format.service';
-import {TestBed} from '@angular/core/testing';
-import {LOCALE_ID} from '@angular/core';
+import { FormatOptions, NumberFormatService, StripOptions } from './number-format.service';
+import { TestBed } from '@angular/core/testing';
+import { LOCALE_ID } from '@angular/core';
 
 describe('NumberFormatService', () => {
   let service: NumberFormatService;
@@ -8,10 +8,7 @@ describe('NumberFormatService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        NumberFormatService,
-        { provide: LOCALE_ID, useValue: localeIdMock },
-      ],
+      providers: [NumberFormatService, { provide: LOCALE_ID, useValue: localeIdMock }],
     });
     service = TestBed.inject(NumberFormatService);
   });
@@ -51,8 +48,8 @@ describe('NumberFormatService', () => {
 
   describe('strip', () => {
     it('should strip string number', () => {
-      const result = service.strip('1234,8', {decimalPlaces: 2} as StripOptions);
-      const resultWithDot = service.strip('1234.8', {decimalPlaces: 2} as StripOptions);
+      const result = service.strip('1234,8', { decimalPlaces: 2 } as StripOptions);
+      const resultWithDot = service.strip('1234.8', { decimalPlaces: 2 } as StripOptions);
       expect(result).toEqual('1234,8');
       expect(resultWithDot).toEqual('12348');
     });

--- a/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
@@ -1,0 +1,92 @@
+import {FormatOptions, NumberFormatService, StripOptions} from './number-format.service';
+import {TestBed} from '@angular/core/testing';
+import {LOCALE_ID} from '@angular/core';
+
+describe('NumberFormatService', () => {
+  let service: NumberFormatService;
+  const localeIdMock = 'de';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        NumberFormatService,
+        { provide: LOCALE_ID, useValue: localeIdMock },
+      ],
+    });
+    service = TestBed.inject(NumberFormatService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('format/formatNumber', () => {
+    it('should return formatted number with default separators', () => {
+      const result = service.format(1234567.89, { decimalPlaces: 2 } as FormatOptions);
+      expect(result).toEqual('1.234.567,89');
+    });
+
+    it('should return formatted number with populated separators', () => {
+      service.decimalSeparator = ',';
+      service.groupingSeparator = '.';
+      const result = service.format(1234567.89, { decimalPlaces: 2 } as FormatOptions);
+      expect(result).toEqual('1.234.567,89');
+    });
+
+    it('should return empty string if the value is not set', () => {
+      const result = service.format(undefined, {} as FormatOptions);
+      expect(result).toEqual('');
+    });
+
+    it('should return formatted number with populated autofillDecimals', () => {
+      const result = service.format(1234567.89, { autofillDecimals: true } as FormatOptions);
+      expect(result).toEqual('1.234.567,89');
+    });
+
+    it('should return formatted number with populated autofillDecimals and decimalPlaces', () => {
+      const result = service.format(1234567, { decimalPlaces: 2, autofillDecimals: true } as FormatOptions);
+      expect(result).toEqual('1.234.567,00');
+    });
+  });
+
+  describe('strip', () => {
+    it('should strip string number', () => {
+      const result = service.strip('1234,8', {decimalPlaces: 2} as StripOptions);
+      const resultWithDot = service.strip('1234.8', {decimalPlaces: 2} as StripOptions);
+      expect(result).toEqual('1234,8');
+      expect(resultWithDot).toEqual('12348');
+    });
+
+    it('should remove decimal separator when decimalPlaces set to zero', () => {
+      const result = service.strip('1234,56', { decimalPlaces: 0 } as StripOptions);
+      const resultWithDot = service.strip('1234.56', { decimalPlaces: 0 } as StripOptions);
+      expect(result).toEqual('1234');
+      expect(resultWithDot).toEqual('123456');
+    });
+
+    it('should remove subsequent decimal separators', () => {
+      const result = service.strip('1234,56,78', { decimalPlaces: 2 } as StripOptions);
+      expect(result).toEqual('1234,56');
+    });
+
+    it('should remove leading zero if not the only zero in the string', () => {
+      const result = service.strip('01234', { decimalPlaces: 4, removeLeadingZeros: true } as StripOptions);
+      expect(result).toEqual('1234');
+    });
+
+    it('should ignore decimal values after maximum decimal places reached', () => {
+      const result = service.strip('1234,5678', { decimalPlaces: 2 } as StripOptions);
+      expect(result).toEqual('1234,56');
+    });
+
+    it('should stop parsing after invalid character', () => {
+      const result = service.strip('1234,56a789', { decimalPlaces: 4 } as StripOptions);
+      expect(result).toEqual('1234,56');
+    });
+
+    it('should parsing negative value', () => {
+      const result = service.strip('-1234,56', { decimalPlaces: 2 } as StripOptions);
+      expect(result).toEqual('-1234,56');
+    });
+  });
+});

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NumericFieldDirective } from './numeric-field.directive';
 import { FormsModule } from '@angular/forms';
 import { Component, DebugElement } from '@angular/core';
@@ -10,14 +10,14 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 @Component({
   template: ` <mat-form-field>
-    <input data-testid="simple" matInput unit="kg" [(ngModel)]="value" madNumericField />
-  </mat-form-field>
-  <mat-form-field>
-    <input data-testid="rightUnit" matInput unit="kg" unitPosition="right" textAlign="left" [(ngModel)]="value" madNumericField/>
-  </mat-form-field>
-  <mat-form-field>
-    <input data-testid="leftUnit" matInput unit="kg" unitPosition="left" textAlign="left" [(ngModel)]="value" madNumericField/>
-  </mat-form-field>`,
+      <input data-testid="simple" matInput unit="kg" [(ngModel)]="value" madNumericField />
+    </mat-form-field>
+    <mat-form-field>
+      <input data-testid="rightUnit" matInput unit="kg" unitPosition="right" textAlign="left" [(ngModel)]="value" madNumericField />
+    </mat-form-field>
+    <mat-form-field>
+      <input data-testid="leftUnit" matInput unit="kg" unitPosition="left" textAlign="left" [(ngModel)]="value" madNumericField />
+    </mat-form-field>`,
 })
 class TestComponent {
   public value: number;
@@ -84,7 +84,7 @@ describe('NumericFieldDirective', () => {
     fixture.detectChanges();
     expect(rightUnitInputDirective.unit).toEqual('kg');
     expect(rightUnitInputDirective.unitPosition).toEqual('right');
-  })
+  });
 
   it('Should set unitPosition to left and textAlign to left and inject unitSpan', () => {
     leftUnitInputEl.nativeElement.value = '123.456';
@@ -92,7 +92,7 @@ describe('NumericFieldDirective', () => {
     fixture.detectChanges();
     expect(leftUnitInputDirective.unit).toEqual('kg');
     expect(leftUnitInputDirective.unitPosition).toEqual('left');
-  })
+  });
 
   it('Should fire keydown backspace event', () => {
     leftUnitInputEl.nativeElement.value = '123456,';
@@ -101,8 +101,7 @@ describe('NumericFieldDirective', () => {
     fixture.detectChanges();
 
     expect(leftUnitInputEl.nativeElement.value).toEqual('12345,');
-  })
-
+  });
 
   it('Should fire keydown delete event', () => {
     leftUnitInputEl.nativeElement.value = '123,56';
@@ -113,7 +112,7 @@ describe('NumericFieldDirective', () => {
     fixture.detectChanges();
 
     expect(leftUnitInputEl.nativeElement.value).toEqual('123,6');
-  })
+  });
 
   it('Should fire keyup backspace event', () => {
     leftUnitInputEl.nativeElement.value = '123456,';
@@ -122,7 +121,7 @@ describe('NumericFieldDirective', () => {
     fixture.detectChanges();
 
     expect(leftUnitInputEl.nativeElement.value).toEqual('123,456');
-  })
+  });
 
   it('Should fire keyup backspace event', () => {
     leftUnitInputEl.nativeElement.value = '123456,';
@@ -130,5 +129,5 @@ describe('NumericFieldDirective', () => {
     fixture.detectChanges();
 
     expect(leftUnitInputEl.nativeElement.value).toEqual('123,456');
-  })
+  });
 });

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
@@ -1,0 +1,134 @@
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import { NumericFieldDirective } from './numeric-field.directive';
+import { FormsModule } from '@angular/forms';
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { NumberFormatService } from './number-format.service';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+@Component({
+  template: ` <mat-form-field>
+    <input data-testid="simple" matInput unit="kg" [(ngModel)]="value" madNumericField />
+  </mat-form-field>
+  <mat-form-field>
+    <input data-testid="rightUnit" matInput unit="kg" unitPosition="right" textAlign="left" [(ngModel)]="value" madNumericField/>
+  </mat-form-field>
+  <mat-form-field>
+    <input data-testid="leftUnit" matInput unit="kg" unitPosition="left" textAlign="left" [(ngModel)]="value" madNumericField/>
+  </mat-form-field>`,
+})
+class TestComponent {
+  public value: number;
+}
+
+describe('NumericFieldDirective', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let simpleInputEl: DebugElement;
+  let rightUnitInputEl: DebugElement;
+  let leftUnitInputEl: DebugElement;
+  let simpleInputDirective: NumericFieldDirective;
+  let rightUnitInputDirective: NumericFieldDirective;
+  let leftUnitInputDirective: NumericFieldDirective;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestComponent, NumericFieldDirective],
+      imports: [FormsModule, MatFormFieldModule, MatInputModule, NoopAnimationsModule],
+      providers: [NumberFormatService],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    simpleInputEl = fixture.debugElement.query(By.css('[data-testid="simple"]'));
+    simpleInputDirective = simpleInputEl.injector.get(NumericFieldDirective);
+    rightUnitInputEl = fixture.debugElement.query(By.css('[data-testid="rightUnit"]'));
+    Object.defineProperty(rightUnitInputEl.nativeElement, 'offsetWidth', { value: 100, writable: true });
+    rightUnitInputDirective = rightUnitInputEl.injector.get(NumericFieldDirective);
+    leftUnitInputEl = fixture.debugElement.query(By.css('[data-testid="leftUnit"]'));
+    Object.defineProperty(leftUnitInputEl.nativeElement, 'offsetWidth', { value: 100, writable: true });
+    leftUnitInputDirective = leftUnitInputEl.injector.get(NumericFieldDirective);
+    fixture.detectChanges();
+  });
+
+  it('should create an instance', () => {
+    expect(simpleInputDirective).not.toBeNull();
+  });
+
+  it('Should update numericValue on input change', () => {
+    simpleInputEl.nativeElement.value = '123.456';
+    simpleInputEl.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(component.value).toEqual(123.45);
+    expect(simpleInputDirective.unit).toEqual('kg');
+  });
+
+  it('Should set default params properly', () => {
+    simpleInputEl.nativeElement.dispatchEvent(new Event('input'));
+
+    expect(simpleInputEl.classes['text-right']).toBeTruthy();
+    expect(simpleInputDirective.textAlign).toEqual('right');
+    expect(simpleInputDirective.decimalPlaces).toEqual(2);
+    expect(simpleInputDirective.roundValue).toBeFalsy();
+    expect(simpleInputDirective.autofillDecimals).toBeFalsy();
+    expect(simpleInputDirective.unitPosition).toEqual('right');
+  });
+
+  it('Should set unitPosition to right and textAlign to left and inject unitSpan', () => {
+    rightUnitInputEl.nativeElement.value = '123.456';
+    rightUnitInputEl.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(rightUnitInputDirective.unit).toEqual('kg');
+    expect(rightUnitInputDirective.unitPosition).toEqual('right');
+  })
+
+  it('Should set unitPosition to left and textAlign to left and inject unitSpan', () => {
+    leftUnitInputEl.nativeElement.value = '123.456';
+    leftUnitInputEl.nativeElement.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    expect(leftUnitInputDirective.unit).toEqual('kg');
+    expect(leftUnitInputDirective.unitPosition).toEqual('left');
+  })
+
+  it('Should fire keydown backspace event', () => {
+    leftUnitInputEl.nativeElement.value = '123456,';
+    let event = new KeyboardEvent('keydown', { keyCode: 8 });
+    leftUnitInputEl.nativeElement.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(leftUnitInputEl.nativeElement.value).toEqual('12345,');
+  })
+
+
+  it('Should fire keydown delete event', () => {
+    leftUnitInputEl.nativeElement.value = '123,56';
+    let event = new KeyboardEvent('keydown', { keyCode: 46 });
+    Object.defineProperty(leftUnitInputEl.nativeElement, 'selectionStart', { get: () => 3 });
+    Object.defineProperty(leftUnitInputEl.nativeElement, 'selectionEnd', { get: () => 3 });
+    leftUnitInputEl.nativeElement.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(leftUnitInputEl.nativeElement.value).toEqual('123,6');
+  })
+
+  it('Should fire keyup backspace event', () => {
+    leftUnitInputEl.nativeElement.value = '123456,';
+    let event = new KeyboardEvent('keyup', { keyCode: 8 });
+    leftUnitInputEl.nativeElement.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(leftUnitInputEl.nativeElement.value).toEqual('123,456');
+  })
+
+  it('Should fire keyup backspace event', () => {
+    leftUnitInputEl.nativeElement.value = '123456,';
+    leftUnitInputEl.nativeElement.dispatchEvent(new Event('blur'));
+    fixture.detectChanges();
+
+    expect(leftUnitInputEl.nativeElement.value).toEqual('123,456');
+  })
+});

--- a/projects/material-addons/src/lib/quick-list/base-quick-list.component.spec.ts
+++ b/projects/material-addons/src/lib/quick-list/base-quick-list.component.spec.ts
@@ -1,8 +1,8 @@
-import {BaseQuickListComponent, QuickListItem} from './base-quick-list.component';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {FormArray, FormBuilder, FormControl} from '@angular/forms';
-import {ElementRef, QueryList} from '@angular/core';
-import {Subject} from 'rxjs';
+import { BaseQuickListComponent, QuickListItem } from './base-quick-list.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormArray, FormBuilder, FormControl } from '@angular/forms';
+import { ElementRef, QueryList } from '@angular/core';
+import { Subject } from 'rxjs';
 
 describe('BaseQuickListComponent', () => {
   let component: BaseQuickListComponent<QuickListItem>;
@@ -11,9 +11,7 @@ describe('BaseQuickListComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [BaseQuickListComponent],
-      providers: [
-        FormBuilder
-      ]
+      providers: [FormBuilder],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BaseQuickListComponent<QuickListItem>);
@@ -79,12 +77,12 @@ describe('BaseQuickListComponent', () => {
     const fakeQueryList = {
       changes: change.asObservable(),
       length: 1,
-      last: { nativeElement: { querySelector: jest.fn().mockImplementation(() => ({ focus: jest.fn() })) } }
+      last: { nativeElement: { querySelector: jest.fn().mockImplementation(() => ({ focus: jest.fn() })) } },
     } as unknown as QueryList<ElementRef>;
     const fakeQueryList2 = {
       changes: change.asObservable(),
       length: 2,
-      last: { nativeElement: { querySelector: jest.fn().mockImplementation(() => ({ focus: jest.fn() })) } }
+      last: { nativeElement: { querySelector: jest.fn().mockImplementation(() => ({ focus: jest.fn() })) } },
     } as unknown as QueryList<ElementRef>;
     component.itemRows = fakeQueryList;
     component.ngAfterViewInit();

--- a/projects/material-addons/src/lib/quick-list/base-quick-list.component.spec.ts
+++ b/projects/material-addons/src/lib/quick-list/base-quick-list.component.spec.ts
@@ -1,0 +1,155 @@
+import {BaseQuickListComponent, QuickListItem} from './base-quick-list.component';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormArray, FormBuilder, FormControl} from '@angular/forms';
+import {ElementRef, QueryList} from '@angular/core';
+import {Subject} from 'rxjs';
+
+describe('BaseQuickListComponent', () => {
+  let component: BaseQuickListComponent<QuickListItem>;
+  let fixture: ComponentFixture<BaseQuickListComponent<QuickListItem>>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [BaseQuickListComponent],
+      providers: [
+        FormBuilder
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BaseQuickListComponent<QuickListItem>);
+    component = fixture.componentInstance;
+    component.formArray = new FormArray([]);
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('ngOnInit should add items as per minItems', () => {
+    component.minItems = 3;
+    component.ngOnInit();
+    expect(component.allItems.length).toBe(3);
+  });
+
+  it('addItem should add a new item and emit added event', () => {
+    const addedSpy = jest.spyOn(component.added, 'emit');
+    component.addItem();
+    expect(component.allItems.length).toBe(1);
+    expect(addedSpy).toHaveBeenCalledTimes(1);
+    expect(addedSpy).toHaveBeenCalledWith(component.allItems[0]);
+  });
+
+  it('removeItem should remove an item and emit removed event', () => {
+    const item = { id: '1' };
+    component.allItems.push(item);
+    const removedSpy = jest.spyOn(component.removed, 'emit');
+    component.removeItem(item);
+    expect(component.allItems).not.toContain(item);
+    expect(removedSpy).toHaveBeenCalledTimes(1);
+    expect(removedSpy).toHaveBeenCalledWith(item);
+  });
+
+  it('isAddAllowed and isDeleteAllowed should work properly with different maxItems and minItems', () => {
+    component.maxItems = 3;
+    component.minItems = 1;
+    expect(component.isAddAllowed()).toBeTruthy();
+    expect(component.isDeleteAllowed()).toBeFalsy();
+    component.allItems.push({ id: '1' }, { id: '2' }, { id: '3' });
+    expect(component.isAddAllowed()).toBeFalsy();
+    expect(component.isDeleteAllowed()).toBeTruthy();
+  });
+
+  it('ngAfterViewInit should call setFocusOnAdd', () => {
+    jest.useFakeTimers();
+    const spy = jest.spyOn(component, 'setFocusOnAdd');
+    component.ngAfterViewInit();
+    jest.advanceTimersByTime(1);
+
+    expect(spy).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
+  it('ngAfterViewInit should call setFocusOnAdd and set focus to another query item', () => {
+    jest.useFakeTimers();
+    const change = new Subject();
+    const spy = jest.spyOn(component, 'setFocusOnAdd');
+    const fakeQueryList = {
+      changes: change.asObservable(),
+      length: 1,
+      last: { nativeElement: { querySelector: jest.fn().mockImplementation(() => ({ focus: jest.fn() })) } }
+    } as unknown as QueryList<ElementRef>;
+    const fakeQueryList2 = {
+      changes: change.asObservable(),
+      length: 2,
+      last: { nativeElement: { querySelector: jest.fn().mockImplementation(() => ({ focus: jest.fn() })) } }
+    } as unknown as QueryList<ElementRef>;
+    component.itemRows = fakeQueryList;
+    component.ngAfterViewInit();
+    jest.advanceTimersByTime(1);
+
+    expect(spy).toHaveBeenCalled();
+    expect(component.rowCountFocus).toBe(fakeQueryList.length);
+    change.next(fakeQueryList2);
+    expect(component.rowCountFocus).toBe(fakeQueryList2.length);
+
+    jest.useRealTimers();
+  });
+
+  it('isAddReactiveAllowed should return based on maxItems and the formArray controls length', () => {
+    component.maxItems = 2;
+    component.addPossible = true;
+    component.formArray.push(new FormControl());
+    expect(component.isAddReactiveAllowed()).toBeTruthy();
+    component.formArray.push(new FormControl());
+    expect(component.isAddReactiveAllowed()).toBeFalsy();
+  });
+
+  it('addReactiveItem should emit when item addition is allowed', () => {
+    const spy = jest.spyOn(component.added, 'emit');
+    component.maxItems = 2;
+    component.addPossible = true;
+    component.addReactiveItem();
+    expect(spy).toHaveBeenCalledWith(null);
+  });
+
+  it('addReactiveItem should not emit when item addition is not allowed', () => {
+    const spy = jest.spyOn(component.added, 'emit');
+    component.maxItems = 0;
+    component.addPossible = false;
+    component.addReactiveItem();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('isDeleteReactiveAllowed should return true or false based on minItems and the formArray controls length', () => {
+    component.minItems = 1;
+    component.removePossible = true;
+    component.formArray.push(new FormControl());
+    component.formArray.push(new FormControl());
+    expect(component.isDeleteReactiveAllowed()).toBeTruthy();
+    component.formArray.removeAt(1);
+    expect(component.isDeleteReactiveAllowed()).toBeFalsy();
+  });
+
+  it('removeReactiveItem should remove and emit when item deletion is allowed', () => {
+    const formControl = new FormControl();
+    component.formArray.push(formControl);
+    const spy = jest.spyOn(component.removed, 'emit');
+    component.removePossible = true;
+    component.removeReactiveItem(formControl);
+    expect(component.formArray.controls).not.toContain(formControl);
+    expect(spy).toHaveBeenCalledWith(null);
+  });
+
+  it('removeReactiveItem should not remove or emit when item deletion is not allowed', () => {
+    const formControl = new FormControl();
+    component.formArray.push(formControl);
+    const spy = jest.spyOn(component.removed, 'emit');
+    component.removePossible = false;
+    component.removeReactiveItem(formControl);
+    expect(component.formArray.controls).toContain(formControl);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/projects/material-addons/tsconfig.spec.json
+++ b/projects/material-addons/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
     "types": [
-      "jasmine"
+      "jest"
     ]
   },
   "files": [

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": ["jasmine", "node"]
+    "types": ["jest"]
   },
   "files": ["src/test.ts", "src/polyfills.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]


### PR DESCRIPTION
### Description

Add Jest configuration and unit tests for components, services and directives
The next unit test coverage achieved:
![image](https://github.com/porscheinformatik/material-addons/assets/43646328/8c4fed91-b210-4086-a873-78787b21033a)


### Which Component is affected or generated?
Not direct affect. Just added new spec files to the next:

- danger-button.component
- link.button.component
- mad-button.directive
- mad-button-group.component
- card.component
- data-table.component
- data-table-columns-modal.component
- number-format.service
- numeric-field.directive
- base-quick-list.component
