### PR TITLE
extend readonly form field

### DIFF
--- a/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.html
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.html
@@ -2,28 +2,31 @@
   <mat-label>{{ label }}</mat-label>
   <input
     *ngIf="!multiline"
+    [ngStyle]="{'display': useProjectedContent ? 'none' : 'block' }"
     [ngModel]="value"
     [ngClass]="'text-' + textAlign + ' content'"
     [errorStateMatcher]="errorMatcher"
     [id]="id"
     readonly
-    disabled
+    [disabled]="!useProjectedContent"
     matInput
     #inputEl
   />
 
   <textarea
     *ngIf="multiline"
+    [ngStyle]="{'display': useProjectedContent ? 'none' : 'block' }"
     [rows]="rows"
     [ngModel]="value"
     class="multiline content"
     [errorStateMatcher]="errorMatcher"
     [id]="id"
     readonly
-    disabled
+    [disabled]="!useProjectedContent"
     matInput
     [cdkTextareaAutosize]="multilineAutoSize"
   ></textarea>
+  <ng-content *ngIf="useProjectedContent" />
   <mat-error>{{ errorMessage }}</mat-error>
   <mat-icon *ngIf="suffix" (click)="suffixClicked()" class="pointer" color="primary" matSuffix>{{ suffix }}</mat-icon>
   <mat-icon *ngIf="prefix" (click)="prefixClicked()" class="pointer" color="primary" matPrefix>{{ prefix }}</mat-icon>

--- a/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
@@ -28,6 +28,7 @@ import { NumberFormatService } from '../../numeric-field/number-format.service';
 export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
   @ViewChild('contentWrapper', { static: false })
   originalContent: ElementRef;
+  @Input('useProjectedContent') useProjectedContent: boolean = false;
   @Input('value') value: any;
   @Input('label') label: string;
   @Input('textAlign') textAlign: 'right' | 'left' = 'left';

--- a/src/app/example-components/read-only-field/read-only-field.component.html
+++ b/src/app/example-components/read-only-field/read-only-field.component.html
@@ -10,6 +10,7 @@
 <mad-readonly-form-field [value]="123456" [label]="'Long number, not formatted (default)'"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="123456" [label]="'Long number, formatted as number'" [formatNumber]="true"></mad-readonly-form-field>
 <mad-readonly-form-field [value]="zeroValue" [label]="'Zero value'"></mad-readonly-form-field>
+<mad-readonly-form-field [label]="'I am a link'" [useProjectedContent]="true"><a href="www.google.com" target="_blank">TADA</a></mad-readonly-form-field>
 <mad-readonly-form-field
   [value]="12000000000"
   [label]="'Number with percentage suffix'"


### PR DESCRIPTION
### Description

Add functionality of displaying content (other than text) inside the mad-readonly-form-field

### Which Component is affected or generated?

ReadOnlyFormFieldComponent
<img width="123" alt="image" src="https://github.com/porscheinformatik/material-addons/assets/158445110/f9b328a1-8099-45a8-a813-17855271978f">