### PR TITLE
Moved text-overflow and ellipsis logic from readonly-form-field-wrapp…

### DIFF
--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
@@ -24,10 +24,6 @@
       [multilineAutoSize]="multilineAutoSize"
       (suffixClickedEmitter)="suffixClicked()"
       (prefixClickedEmitter)="prefixClicked()"
-      matTooltip="{{ toolTipText }}"
-      matTooltipPosition="right"
-      matTooltipClass="custom-tooltip"
-      matTooltipDisabled="{{ !toolTipForInputEnabled }}"
     >
     </mad-readonly-form-field>
   </ng-container>

--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
@@ -91,12 +91,9 @@ export class ReadOnlyFormFieldWrapperComponent implements OnInit, AfterViewInit,
    */
   label: string;
 
-  toolTipForInputEnabled = false;
-  toolTipText: string;
 
   constructor(
     private changeDetector: ChangeDetectorRef,
-    private elementRef: ElementRef,
     private rootFormGroup: FormGroupDirective
   ) {
   }
@@ -106,14 +103,11 @@ export class ReadOnlyFormFieldWrapperComponent implements OnInit, AfterViewInit,
   }
 
   ngAfterViewInit(): void {
-    this.setReadonlyFieldStyle();
     this.doRendering();
     this.extractValue();
   }
 
   ngAfterViewChecked(): void {
-    this.setReadonlyFieldStyle();
-    this.setTooltipForOverflownField();
   }
 
   ngOnChanges(_: SimpleChanges): void {
@@ -183,59 +177,4 @@ export class ReadOnlyFormFieldWrapperComponent implements OnInit, AfterViewInit,
     }
   }
 
-  private setReadonlyFieldStyle(): void {
-    const input = this.readOnlyContentWrapper?.nativeElement?.querySelector('input');
-
-    if (input) {
-      const textOverFlowStyleValue = this.getTextOverFlowStyleValue();
-      if (textOverFlowStyleValue) {
-        input.setAttribute('style', 'text-overflow: ' + textOverFlowStyleValue);
-      }
-    }
-  }
-
-  // Ellipsis is enabled by default as text-overflow behaviour
-  private getTextOverFlowStyleValue(): string {
-    // it works only if the style is added to the component directly. Should find a way for get it from the calculated
-    // style. Than it would be possible to define the text-overflow in css for the whole application
-    const textOverflow = this.elementRef?.nativeElement?.style.textOverflow;
-    if (!textOverflow) {
-      return 'ellipsis';
-    }
-
-    return textOverflow;
-  }
-
-  private setTooltipForOverflownField(): void {
-    if (this.isEllipsisForTextOverflowEnabled()) {
-      const input = this.readOnlyContentWrapper?.nativeElement?.querySelector('input');
-
-      if (input) {
-        this.toolTipForInputEnabled = this.isTextOverflown(input);
-        if (this.toolTipForInputEnabled) {
-          this.toolTipText = this.calculateToolTipText();
-        }
-        this.changeDetector.detectChanges();
-      }
-    }
-  }
-
-  private isEllipsisForTextOverflowEnabled(): boolean {
-    return this.getTextOverFlowStyleValue() === 'ellipsis';
-  }
-
-  private isTextOverflown(input: any): boolean {
-    if (input) {
-      return input.offsetWidth < input.scrollWidth;
-    }
-    return false;
-  }
-
-  private calculateToolTipText(): string {
-    if (!this.unit) {
-      return this.value;
-    }
-
-    return this.unitPosition === 'left' ? this.unit + ' ' + this.value : this.value + ' ' + this.unit;
-  }
 }

--- a/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.html
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.html
@@ -11,6 +11,10 @@
     [disabled]="!useProjectedContent"
     matInput
     #inputEl
+    matTooltip="{{ toolTipText }}"
+    matTooltipPosition="right"
+    matTooltipClass="custom-tooltip"
+    matTooltipDisabled="{{ !toolTipForInputEnabled }}"
   />
 
   <textarea

--- a/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field/readonly-form-field.component.ts
@@ -71,10 +71,14 @@ export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
   private unitSpan: HTMLSpanElement;
   private textSpan: HTMLSpanElement;
 
+  toolTipForInputEnabled = false;
+  toolTipText: string;
+
   constructor(
     private changeDetector: ChangeDetectorRef,
     private renderer: Renderer2,
     private numberFormatService: NumberFormatService,
+    private elementRef: ElementRef,
   ) {}
 
   ngOnChanges(_: SimpleChanges): void {
@@ -96,6 +100,8 @@ export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
   // TODO direct copy from NumericFieldDirective
   ngAfterViewChecked(): void {
     this.injectUnitSymbol();
+    this.setReadonlyFieldStyle();
+    this.setTooltipForOverflownField();
   }
 
   suffixClicked() {
@@ -155,5 +161,58 @@ export class ReadOnlyFormFieldComponent implements OnChanges, AfterViewChecked {
     if (!!this.unitSpan) {
       this.unitSpan.textContent = this.unit;
     }
+  }
+
+  private setReadonlyFieldStyle(): void {
+    if (this.inputEl?.nativeElement) {
+      const textOverFlowStyleValue = this.getTextOverFlowStyleValue();
+      if (textOverFlowStyleValue) {
+        this.inputEl.nativeElement.setAttribute('style', 'text-overflow: ' + textOverFlowStyleValue);
+      }
+    }
+  }
+
+  // Ellipsis is enabled by default as text-overflow behaviour
+  private getTextOverFlowStyleValue(): string {
+    // it works only if the style is added to the component directly. Should find a way for get it from the calculated
+    // style. Than it would be possible to define the text-overflow in css for the whole application
+    const textOverflow = this.elementRef?.nativeElement?.style.textOverflow;
+    if (!textOverflow) {
+      return 'ellipsis';
+    }
+
+    return textOverflow;
+  }
+
+  private setTooltipForOverflownField(): void {
+    if (this.isEllipsisForTextOverflowEnabled()) {
+
+      if (this.inputEl) {
+        this.toolTipForInputEnabled = this.isTextOverflown(this.inputEl.nativeElement);
+        if (this.toolTipForInputEnabled) {
+          this.toolTipText = this.calculateToolTipText();
+        }
+        this.changeDetector.detectChanges();
+      }
+    }
+  }
+
+  private isEllipsisForTextOverflowEnabled(): boolean {
+    return this.getTextOverFlowStyleValue() === 'ellipsis';
+  }
+
+  private isTextOverflown(input: any): boolean {
+    if (input) {
+      return input.offsetWidth < input.scrollWidth;
+    }
+    return false;
+  }
+
+  private calculateToolTipText(): string {
+    if (!this.unit) {
+      return this.value;
+    }
+
+    return this.unitPosition === 'left' ? this.unit + ' ' + this.value : this.value + ' ' + this.unit;
   }
 }


### PR DESCRIPTION
…er.component to readonly-form-field.component

### Description

Moved ellipsis & text-overflow logic from readonly-form-field-wrapper.component to readonly-form-field.component
Since the wrapper component was runs the logic to manipulate the input INSIDE the readonly-form-field. meaning that such logic was not only not available in the readonly form field but being triggered by its parent only.

### Which Component is affected or generated?

readonly-form-field-wrapper.component 
readonly-form-field.component
