### PR TITLE
removed general vertical-align styling for mat-icons

### DIFF
--- a/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.html
+++ b/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.html
@@ -2,7 +2,7 @@
   <ng-content select="label"></ng-content>
 </h3>
 <ng-container *ngFor="let item of allItems; let isLast = last">
-  <div class="flex-container" *ngIf="itemTemplate" #row style="display: flex; flex-direction: row">
+  <div class="flex-container" *ngIf="itemTemplate" #row class="quick-list-row">
     <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
     <mad-icon-button data-cy="delete-item-button" *ngIf="!readonly && isDeleteAllowed()" (click)="removeItem(item)">
       <mat-icon>delete</mat-icon>

--- a/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.ts
+++ b/projects/material-addons/src/lib/quick-list/quick-list-compact/quick-list-compact.component.ts
@@ -5,15 +5,7 @@ import { FormBuilder } from '@angular/forms';
 @Component({
   selector: 'mad-quick-list-compact',
   templateUrl: './quick-list-compact.component.html',
-  styles: [
-    `
-      .quick-list-row {
-        flex-direction: row;
-        box-sizing: border-box;
-        display: flex;
-      }
-    `,
-  ],
+  styleUrls: [],
 })
 export class QuickListCompactComponent extends BaseQuickListComponent<QuickListItem> {
   constructor(

--- a/projects/material-addons/src/lib/quick-list/quick-list.component.html
+++ b/projects/material-addons/src/lib/quick-list/quick-list.component.html
@@ -2,7 +2,7 @@
   <ng-content select="label"></ng-content>
 </h3>
 <ng-container *ngFor="let item of allItems">
-  <div *ngIf="itemTemplate" #row style="display: flex; flex-direction: row">
+  <div *ngIf="itemTemplate" #row class="quick-list-row">
     <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
     <mad-icon-button data-cy="delete-item-button" *ngIf="!readonly && isDeleteAllowed()" (click)="removeItem(item)">
       <mat-icon>delete</mat-icon>

--- a/projects/material-addons/src/lib/quick-list/reactive-form-quick-list-compact/reactive-form-quick-list-compact.component.html
+++ b/projects/material-addons/src/lib/quick-list/reactive-form-quick-list-compact/reactive-form-quick-list-compact.component.html
@@ -2,7 +2,7 @@
   <ng-content select="label"></ng-content>
 </h3>
 <ng-container *ngFor="let item of formArray.controls; let isLast = last">
-  <div *ngIf="itemTemplate" #row style="display: flex; flex-direction: row">
+  <div *ngIf="itemTemplate" #row class="quick-list-row">
     <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
     <mad-icon-button data-cy="delete-item-button" *ngIf="!readonly && isDeleteReactiveAllowed()" (click)="removeReactiveItem(item)">
       <mat-icon>delete</mat-icon>

--- a/projects/material-addons/src/lib/quick-list/reactive-form-quick-list/reactive-form-quick-list.component.html
+++ b/projects/material-addons/src/lib/quick-list/reactive-form-quick-list/reactive-form-quick-list.component.html
@@ -2,7 +2,7 @@
   <ng-content select="label"></ng-content>
 </h3>
 <ng-container *ngFor="let item of formArray.controls">
-  <div *ngIf="itemTemplate" #row style="display: flex; flex-direction: row">
+  <div *ngIf="itemTemplate" #row class="quick-list-row">
     <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
     <mad-icon-button data-cy="delete-item-button" *ngIf="!readonly && isDeleteReactiveAllowed()" (click)="removeReactiveItem(item)">
       <mat-icon>delete</mat-icon>

--- a/projects/material-addons/src/themes/common/styles.scss
+++ b/projects/material-addons/src/themes/common/styles.scss
@@ -250,10 +250,6 @@ mad-danger-button {
   text-transform: uppercase !important;
 }
 
-.mat-icon {
-  vertical-align: middle;
-}
-
 .toolbar-title {
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -490,4 +486,12 @@ mat-form-field .mat-mdc-form-field {
 
 .pointer {
   cursor: pointer;
+}
+
+.quick-list-row {
+  display: flex;
+  flex-direction: row;
+  mad-icon-button {
+    margin-top: 8px;
+  }
 }


### PR DESCRIPTION
fixed alignment of icon-button within quick-list components and its derived classes

### Description

Fix alignment of buttons inside quick list and its derived components

### Which Component is affected or generated?

<!--- Specify which component is changed or is added to the material addons -->

quick-compact.component
quick-list-compact.component
reactive-form-quick-list.component
reactive-form-quick-list-compact.component