### PR TITLE
Fix mad-toolbar main action buttons with icons

### DIFF
--- a/projects/material-addons/src/lib/layout/toolbar/toolbar.component.html
+++ b/projects/material-addons/src/lib/layout/toolbar/toolbar.component.html
@@ -22,14 +22,18 @@
       <div *ngIf="!(isHandset$ | async)">
         <a data-cy="main-action-link-button" [routerLink]="mainAction.routerLink" *ngIf="isRouterLink(mainAction)">
           <mad-primary-button [id]="mainAction.matIcon" style="margin-left: 56px" [matTooltip]="mainAction.tooltip">
-            <mat-icon>{{ mainAction.matIcon }}</mat-icon>
-            {{ mainAction.actionName }}
+            <div class="action-button-content-container">
+              <mat-icon>{{ mainAction.matIcon }}</mat-icon>
+              {{ mainAction.actionName }}
+            </div>
           </mad-primary-button>
         </a>
         <a data-cy="main-action-button" (click)="mainAction.action()" *ngIf="isAction(mainAction)">
           <mad-primary-button [id]="mainAction.matIcon" style="margin-left: 56px" [matTooltip]="mainAction.tooltip">
-            <mat-icon>{{ mainAction.matIcon }}</mat-icon>
-            {{ mainAction.actionName }}
+            <div class="action-button-content-container">
+              <mat-icon>{{ mainAction.matIcon }}</mat-icon>
+              {{ mainAction.actionName }}
+            </div>
           </mad-primary-button>
         </a>
       </div>

--- a/projects/material-addons/src/lib/layout/toolbar/toolbar.component.scss
+++ b/projects/material-addons/src/lib/layout/toolbar/toolbar.component.scss
@@ -26,3 +26,9 @@ mat-toolbar {
   bottom: -7px !important;
   right: -7px !important;
 }
+
+.action-button-content-container {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}


### PR DESCRIPTION
### Description

mad-toolbar action button with icon displays incorrectly:
![image](https://github.com/porscheinformatik/material-addons/assets/43646328/1cc77c7a-4c0d-4e4b-881b-2a1c0bf6ac54)

Added styled internal container for action button content
After fix looks like that:
![image](https://github.com/porscheinformatik/material-addons/assets/43646328/be13aa86-7060-4bf4-a788-0fa2d8cb07f3)


### Which Component is affected or generated?

- mad-toolbar
