### PR TITLE
Detect ng content changes in read only form field wrapper

### DIFF
--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.html
@@ -1,4 +1,4 @@
-<div #contentWrapper [hidden]="readonly">
+<div #contentWrapper [hidden]="readonly"  (cdkObserveContent)="onContentChange()">
   <ng-content></ng-content>
 </div>
 

--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
@@ -135,6 +135,11 @@ export class ReadOnlyFormFieldWrapperComponent implements OnInit, AfterViewInit,
     this.prefixClickedEmitter.emit(null);
   }
 
+  onContentChange(): void {
+    this.extractLabel();
+    this.extractValue();
+  }
+
   private doRendering(): void {
     if (!this.originalContent) {
       return;

--- a/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field-wrapper/readonly-form-field-wrapper.component.ts
@@ -12,9 +12,10 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { ControlContainer, FormGroupDirective } from '@angular/forms';
-import { ReadOnlyFormFieldComponent } from '../readonly-form-field/readonly-form-field.component';
-import { NgIf } from '@angular/common';
+import {ControlContainer, FormGroupDirective} from '@angular/forms';
+import {ReadOnlyFormFieldComponent} from '../readonly-form-field/readonly-form-field.component';
+import {NgIf} from '@angular/common';
+import {ObserversModule} from "@angular/cdk/observers";
 
 /**
  * Wraps a mat-form-field to replace it by a readOnly representation if necessary
@@ -27,7 +28,7 @@ import { NgIf } from '@angular/common';
   styleUrls: ['./readonly-form-field-wrapper.component.css'],
   viewProviders: [{ provide: ControlContainer, useExisting: FormGroupDirective }],
   standalone: true,
-  imports: [NgIf, ReadOnlyFormFieldComponent],
+  imports: [NgIf, ReadOnlyFormFieldComponent, ObserversModule],
 })
 export class ReadOnlyFormFieldWrapperComponent implements OnInit, AfterViewInit, OnChanges, AfterViewChecked {
   @ViewChild('contentWrapper', { static: false })

--- a/projects/material-addons/src/lib/readonly/readonly-form-field.module.ts
+++ b/projects/material-addons/src/lib/readonly/readonly-form-field.module.ts
@@ -8,10 +8,11 @@ import {MatInputModule} from '@angular/material/input';
 import {FormGroupDirective, FormsModule} from '@angular/forms';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {MatIconModule} from '@angular/material/icon';
+import {ObserversModule} from "@angular/cdk/observers";
 
 @NgModule({
   declarations: [ReadOnlyFormFieldComponent, ReadOnlyFormFieldWrapperComponent],
-  imports: [CommonModule, RouterModule, MatFormFieldModule, MatInputModule, FormsModule, MatTooltipModule, MatIconModule],
+    imports: [CommonModule, RouterModule, MatFormFieldModule, MatInputModule, FormsModule, MatTooltipModule, MatIconModule, ObserversModule],
   exports: [ReadOnlyFormFieldComponent, ReadOnlyFormFieldWrapperComponent],
   providers: [FormGroupDirective]
 })


### PR DESCRIPTION
### Description

The Label and Value of the Read Only From Field Wrapper are read after the view inits, but if the label or value changes after, the changes will not be detected for the Read Only Form Field. This change will listen to Content Changes and update the value and the label after a Content Change.

### Which Component is affected or generated?

Read Only Form Field Wrapper
