### PR TITLE
Change NumberFormatService to be providedIn 'root'

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,7 +6,8 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
+      - '**'
 
 jobs:
   build:

--- a/projects/material-addons/src/lib/numeric-field/number-format.service.ts
+++ b/projects/material-addons/src/lib/numeric-field/number-format.service.ts
@@ -1,4 +1,4 @@
-import { Inject, LOCALE_ID, Injectable } from '@angular/core';
+import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 
 export declare interface FormatOptions {
   decimalPlaces?: number;
@@ -15,7 +15,7 @@ export declare interface StripOptions {
 }
 
 @Injectable({
-  providedIn: 'any',
+  providedIn: 'root',
 })
 export class NumberFormatService {
   static readonly NEGATIVE = '-';
@@ -31,6 +31,14 @@ export class NumberFormatService {
   allowedKeys: string[] = [];
 
   constructor(@Inject(LOCALE_ID) locale: string) {
+    this.prepareSeparators(locale);
+  }
+
+  /**
+   * Call this if the locale is changed to update the separators.
+   * @param locale the new locale
+   */
+  public prepareSeparators(locale: string) {
     // try to get the current formatting
     const localeDecimalSeparator = (1.1).toLocaleString(locale).charAt(1);
     this.decimalSeparator = localeDecimalSeparator === ',' ? ',' : '.';

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.module.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.module.ts
@@ -1,17 +1,14 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { NumericFieldDirective } from './numeric-field.directive';
-import { NumberFormatService } from './number-format.service';
 
 @NgModule({
   imports: [NumericFieldDirective],
-  providers: [NumberFormatService],
   exports: [NumericFieldDirective],
 })
 export class NumericFieldModule {
   static forRoot(): ModuleWithProviders<NumericFieldModule> {
     return {
       ngModule: NumericFieldModule,
-      providers: [NumberFormatService],
     };
   }
 }


### PR DESCRIPTION
### Description

Change NumberFormatService to be providedIn 'root'.
This helps to override a dynamically set LOCALE_ID after changing.

### Which Component is affected or generated?

number-format.service.ts