### PR TITLE
Fix dist output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The versioning of material-addons is based on the Angular version. The Angular v
 _Hint: Changes marked as **visible change** directly affect your application during version upgrade. **Breaking**
 requires your attention during upgrade._
 
-- **19.0.1**: bugfix fpr version: fix dist output
+- **19.0.1**: bugfix for version: fix dist output
 - **19.0.0**: Upgrade to Angular 19
 - **18.0.5**: FileUpload: Added additional param as 'removable' which allows user to remove file from fileList [#212](https://github.com/porscheinformatik/material-addons/pull/212)
 - **18.0.3**: Fix MadNumericField: Fix floating point issue when not rounding any values (2.3*100 = 229.999 and displayed as 2.29)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The versioning of material-addons is based on the Angular version. The Angular v
 _Hint: Changes marked as **visible change** directly affect your application during version upgrade. **Breaking**
 requires your attention during upgrade._
 
+- **19.0.1**: bugfix fpr version: fix dist output
 - **19.0.0**: Upgrade to Angular 19
 - **18.0.5**: FileUpload: Added additional param as 'removable' which allows user to remove file from fileList [#212](https://github.com/porscheinformatik/material-addons/pull/212)
 - **18.0.3**: Fix MadNumericField: Fix floating point issue when not rounding any values (2.3*100 = 229.999 and displayed as 2.29)

--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,8 @@
           "builder": "@angular/build:application",
           "options": {
             "outputPath": {
-              "base": "dist/material-addons-project"
+              "base": "dist/material-addons-project",
+              "browser": ""
             },
             "index": "src/index.html",
             "polyfills": ["src/polyfills.ts"],

--- a/projects/material-addons/package.json
+++ b/projects/material-addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@porscheinformatik/material-addons",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "description": "Custom theme and components for Angular Material",
   "homepage": "https://github.com/porscheinformatik/material-addons",
   "repository": {

--- a/projects/material-addons/src/version.ts
+++ b/projects/material-addons/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '19.0.0';
+export const VERSION = '19.0.1';


### PR DESCRIPTION
### Description

After update to v19 dist output was updated. So index.html and other source files were hidden under "browser" folder after build. This is why ghpages cannot find index.html in a root and demo page doesn't work

### Which Component is affected or generated?

Components are not affected
