### PR TITLE
Numeric field refactor

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: ['tsconfig.json', 'tsconfig.app.json', 'tsconfig.spec.json'],
+        project: ['tsconfig.json', 'tsconfig.app.json', 'tsconfig.spec.json', '.storybook/tsconfig.json'],
         tsconfigRootDir: __dirname,
         sourceType: 'module',
       },

--- a/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
@@ -1,89 +1,119 @@
-import { FormatOptions, NumberFormatService, StripOptions } from './number-format.service';
-import { TestBed } from '@angular/core/testing';
-import { LOCALE_ID } from '@angular/core';
+import { describe, expect, it } from '@jest/globals';
+import { NumberFormatService } from './number-format.service';
 
 describe('NumberFormatService', () => {
-  let service: NumberFormatService;
-  const localeIdMock = 'de';
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [NumberFormatService, { provide: LOCALE_ID, useValue: localeIdMock }],
-    });
-    service = TestBed.inject(NumberFormatService);
-  });
+  const createService = (locale = 'de-DE'): NumberFormatService => new NumberFormatService(locale);
 
   it('should be created', () => {
-    expect(service).toBeTruthy();
+    expect(createService()).toBeTruthy();
+  });
+
+  describe('locale separators', () => {
+    it.each([
+      ['de-DE', ',', '.', '1.234.567,89'],
+      ['de-AT', ',', '.', '1.234.567,89'],
+      ['en-EN', '.', ',', '1,234,567.89'],
+    ])('should use supported separators for %s', (locale, decimalSeparator, groupingSeparator, expectedValue) => {
+      const service = createService(locale);
+
+      expect(service.decimalSeparator).toBe(decimalSeparator);
+      expect(service.groupingSeparator).toBe(groupingSeparator);
+      expect(service.format(1234567.89, { decimalPlaces: 2 })).toBe(expectedValue);
+    });
+
+    it('should fall back to English separators for unsupported locales', () => {
+      const service = createService('fr-FR');
+
+      expect(service.decimalSeparator).toBe('.');
+      expect(service.groupingSeparator).toBe(',');
+    });
   });
 
   describe('format/formatNumber', () => {
     it('should return formatted number with default separators', () => {
-      const result = service.format(1234567.89, { decimalPlaces: 2 } as FormatOptions);
-      expect(result).toEqual('1.234.567,89');
+      const service = createService();
+
+      expect(service.format(1234567.89, { decimalPlaces: 2 })).toEqual('1.234.567,89');
     });
 
     it('should return formatted number with populated separators', () => {
+      const service = createService();
       service.decimalSeparator = ',';
       service.groupingSeparator = '.';
-      const result = service.format(1234567.89, { decimalPlaces: 2 } as FormatOptions);
-      expect(result).toEqual('1.234.567,89');
+
+      expect(service.format(1234567.89, { decimalPlaces: 2 })).toEqual('1.234.567,89');
     });
 
     it('should return empty string if the value is not set', () => {
-      const result = service.format(undefined, {} as FormatOptions);
-      expect(result).toEqual('');
+      const service = createService();
+
+      expect(service.format(undefined)).toEqual('');
+      expect(service.format(null)).toEqual('');
     });
 
     it('should return formatted number with populated autofillDecimals', () => {
-      const result = service.format(1234567.89, { autofillDecimals: true } as FormatOptions);
-      expect(result).toEqual('1.234.567,89');
+      const service = createService();
+
+      expect(service.format(1234567.89, { autofillDecimals: true })).toEqual('1.234.567,89');
     });
 
     it('should return formatted number with populated autofillDecimals and decimalPlaces', () => {
-      const result = service.format(1234567, { decimalPlaces: 2, autofillDecimals: true } as FormatOptions);
-      expect(result).toEqual('1.234.567,00');
+      const service = createService();
+
+      expect(service.format(1234567, { decimalPlaces: 2, autofillDecimals: true })).toEqual('1.234.567,00');
+    });
+
+    it('should add a leading zero before decimal values', () => {
+      const service = createService();
+
+      expect(service.formatNumber(',5', { decimalPlaces: 2 })).toEqual('0,5');
+      expect(service.formatNumber('-,5', { decimalPlaces: 2 })).toEqual('-0,5');
     });
   });
 
   describe('strip', () => {
     it('should strip string number', () => {
-      const result = service.strip('1234,8', { decimalPlaces: 2 } as StripOptions);
-      const resultWithDot = service.strip('1234.8', { decimalPlaces: 2 } as StripOptions);
-      expect(result).toEqual('1234,8');
-      expect(resultWithDot).toEqual('12348');
+      const service = createService();
+
+      expect(service.strip('1234,8', { decimalPlaces: 2 })).toEqual('1234,8');
+      expect(service.strip('1234.8', { decimalPlaces: 2 })).toEqual('12348');
     });
 
     it('should remove decimal separator when decimalPlaces set to zero', () => {
-      const result = service.strip('1234,56', { decimalPlaces: 0 } as StripOptions);
-      const resultWithDot = service.strip('1234.56', { decimalPlaces: 0 } as StripOptions);
-      expect(result).toEqual('1234');
-      expect(resultWithDot).toEqual('123456');
+      const service = createService();
+
+      expect(service.strip('1234,56', { decimalPlaces: 0 })).toEqual('1234');
+      expect(service.strip('1234.56', { decimalPlaces: 0 })).toEqual('123456');
     });
 
     it('should remove subsequent decimal separators', () => {
-      const result = service.strip('1234,56,78', { decimalPlaces: 2 } as StripOptions);
-      expect(result).toEqual('1234,56');
+      const service = createService();
+
+      expect(service.strip('1234,56,78', { decimalPlaces: 2 })).toEqual('1234,56');
     });
 
     it('should remove leading zero if not the only zero in the string', () => {
-      const result = service.strip('01234', { decimalPlaces: 4, removeLeadingZeros: true } as StripOptions);
-      expect(result).toEqual('1234');
+      const service = createService();
+
+      expect(service.strip('01234', { decimalPlaces: 4, removeLeadingZeros: true })).toEqual('1234');
     });
 
     it('should ignore decimal values after maximum decimal places reached', () => {
-      const result = service.strip('1234,5678', { decimalPlaces: 2 } as StripOptions);
-      expect(result).toEqual('1234,56');
+      const service = createService();
+
+      expect(service.strip('1234,5678', { decimalPlaces: 2 })).toEqual('1234,56');
     });
 
     it('should stop parsing after invalid character', () => {
-      const result = service.strip('1234,56a789', { decimalPlaces: 4 } as StripOptions);
-      expect(result).toEqual('1234,56');
+      const service = createService();
+
+      expect(service.strip('1234,56a789', { decimalPlaces: 4 })).toEqual('1234,56');
     });
 
-    it('should parsing negative value', () => {
-      const result = service.strip('-1234,56', { decimalPlaces: 2 } as StripOptions);
-      expect(result).toEqual('-1234,56');
+    it('should parse negative value', () => {
+      const service = createService();
+
+      expect(service.strip('-1234,56', { decimalPlaces: 2 })).toEqual('-1234,56');
     });
   });
 });

--- a/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/number-format.service.spec.ts
@@ -3,26 +3,42 @@ import { NumberFormatService } from './number-format.service';
 
 describe('NumberFormatService', () => {
   const createService = (locale = 'de-DE'): NumberFormatService => new NumberFormatService(locale);
+  const getIntlSeparator = (locale: string, type: Intl.NumberFormatPartTypes): string | undefined =>
+    Intl.NumberFormat(locale)
+      .formatToParts(1234.5)
+      .find((part) => part.type === type)?.value;
 
   it('should be created', () => {
     expect(createService()).toBeTruthy();
   });
 
   describe('locale separators', () => {
-    it.each([
-      ['de-DE', ',', '.', '1.234.567,89'],
-      ['de-AT', ',', '.', '1.234.567,89'],
-      ['en-EN', '.', ',', '1,234,567.89'],
-    ])('should use supported separators for %s', (locale, decimalSeparator, groupingSeparator, expectedValue) => {
+    it.each(['de-DE', 'de-AT', 'en-EN'])('should use Intl separators for supported locale %s', (locale) => {
       const service = createService(locale);
+      const decimalSeparator = getIntlSeparator(locale, 'decimal');
+      const groupingSeparator = getIntlSeparator(locale, 'group');
 
       expect(service.decimalSeparator).toBe(decimalSeparator);
       expect(service.groupingSeparator).toBe(groupingSeparator);
-      expect(service.format(1234567.89, { decimalPlaces: 2 })).toBe(expectedValue);
+      expect(service.format(1234567.89, { decimalPlaces: 2 })).toBe(`1${groupingSeparator}234${groupingSeparator}567${decimalSeparator}89`);
     });
 
-    it('should fall back to English separators for unsupported locales', () => {
+    it('should use Intl separators for other supported locales', () => {
       const service = createService('fr-FR');
+      const decimalSeparator = getIntlSeparator('fr-FR', 'decimal');
+      const groupingSeparator = getIntlSeparator('fr-FR', 'group');
+
+      expect(decimalSeparator).toBeTruthy();
+      expect(groupingSeparator).toBeTruthy();
+      expect(groupingSeparator).not.toBe('.');
+      expect(groupingSeparator).not.toBe(',');
+      expect(service.decimalSeparator).toBe(decimalSeparator);
+      expect(service.groupingSeparator).toBe(groupingSeparator);
+      expect(service.format(1234567.89, { decimalPlaces: 2 })).toBe(`1${groupingSeparator}234${groupingSeparator}567${decimalSeparator}89`);
+    });
+
+    it.each(['zz-ZZ', 'invalid_locale'])('should fall back to English separators for unsupported locale %s', (locale) => {
+      const service = createService(locale);
 
       expect(service.decimalSeparator).toBe('.');
       expect(service.groupingSeparator).toBe(',');
@@ -114,6 +130,16 @@ describe('NumberFormatService', () => {
       const service = createService();
 
       expect(service.strip('-1234,56', { decimalPlaces: 2 })).toEqual('-1234,56');
+    });
+
+    it('should ignore locale grouping separators before the decimal separator', () => {
+      const service = createService('fr-FR');
+      const decimalSeparator = getIntlSeparator('fr-FR', 'decimal');
+      const groupingSeparator = getIntlSeparator('fr-FR', 'group');
+
+      expect(service.strip(`1${groupingSeparator}234${groupingSeparator}567${decimalSeparator}89`, { decimalPlaces: 2 })).toEqual(
+        `1234567${decimalSeparator}89`,
+      );
     });
   });
 });

--- a/projects/material-addons/src/lib/numeric-field/number-format.service.ts
+++ b/projects/material-addons/src/lib/numeric-field/number-format.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 
-export declare interface FormatOptions {
+export interface FormatOptions {
   decimalPlaces?: number;
 
   finalFormatting?: boolean;
@@ -8,11 +8,13 @@ export declare interface FormatOptions {
   autofillDecimals?: boolean;
 }
 
-export declare interface StripOptions {
+export interface StripOptions {
   decimalPlaces?: number;
 
   removeLeadingZeros?: boolean;
 }
+
+type NumericSeparator = ',' | '.';
 
 @Injectable({
   providedIn: 'root',
@@ -25,8 +27,8 @@ export class NumberFormatService {
   static readonly DEFAULT_AUTOFILL_DECIMALS = false;
   static readonly DEFAULT_REMOVE_LEADING_ZEROS = false;
 
-  decimalSeparator: ',' | '.';
-  groupingSeparator: ',' | '.';
+  decimalSeparator: NumericSeparator;
+  groupingSeparator: NumericSeparator;
 
   allowedKeys: string[] = [];
 
@@ -34,27 +36,24 @@ export class NumberFormatService {
     this.prepareSeparators(locale);
   }
 
+  static valueIsSet(value: unknown): boolean {
+    return typeof value !== 'undefined' && value !== null && (typeof value !== 'string' || value.length !== 0);
+  }
+
   /**
    * Call this if the locale is changed to update the separators.
    * @param locale the new locale
    */
-  public prepareSeparators(locale: string) {
-    // try to get the current formatting
-    const localeDecimalSeparator = (1.1).toLocaleString(locale).charAt(1);
-    this.decimalSeparator = localeDecimalSeparator === ',' ? ',' : '.';
-    this.groupingSeparator = localeDecimalSeparator === ',' ? '.' : ',';
+  prepareSeparators(locale: string): void {
+    const separators = this.getSeparators(locale);
+    this.decimalSeparator = separators.decimalSeparator;
+    this.groupingSeparator = separators.groupingSeparator;
 
     this.allowedKeys = [...NumberFormatService.NUMBERS, NumberFormatService.NEGATIVE, this.decimalSeparator];
   }
 
-  static valueIsSet(value: any): boolean {
-    return typeof value !== 'undefined' && value !== null && (typeof value !== 'string' || value.length !== 0);
-  }
-
-  format(value: number, options?: Partial<FormatOptions>): string {
-    return NumberFormatService.valueIsSet(value)
-      ? this.formatNumber(value.toString().replace(new RegExp('[.]', 'g'), this.decimalSeparator), options)
-      : '';
+  format(value: number | null | undefined, options?: Partial<FormatOptions>): string {
+    return NumberFormatService.valueIsSet(value) ? this.formatNumber(String(value).replace(/[.]/g, this.decimalSeparator), options) : '';
   }
 
   formatNumber(value: string, options?: Partial<FormatOptions>): string {
@@ -147,6 +146,23 @@ export class NumberFormatService {
     return result;
   }
 
+  private getSeparators(locale: string): {
+    decimalSeparator: NumericSeparator;
+    groupingSeparator: NumericSeparator;
+  } {
+    if (locale === 'de-DE' || locale === 'de-AT' || locale === 'de') {
+      return {
+        decimalSeparator: ',',
+        groupingSeparator: '.',
+      };
+    }
+
+    return {
+      decimalSeparator: '.',
+      groupingSeparator: ',',
+    };
+  }
+
   private addMissingLeadingZero(result: string, actualDecimalIndex: number): string {
     const isNegative = result.startsWith(NumberFormatService.NEGATIVE);
     /* autoadd a zero before decimal separator, when it's missing */
@@ -160,7 +176,7 @@ export class NumberFormatService {
     return result;
   }
 
-  private valueOrDefault(value: any, defaultValue: any): any {
+  private valueOrDefault<T>(value: T | null | undefined, defaultValue: T): T {
     return NumberFormatService.valueIsSet(value) ? value : defaultValue;
   }
 }

--- a/projects/material-addons/src/lib/numeric-field/number-format.service.ts
+++ b/projects/material-addons/src/lib/numeric-field/number-format.service.ts
@@ -14,7 +14,10 @@ export interface StripOptions {
   removeLeadingZeros?: boolean;
 }
 
-type NumericSeparator = ',' | '.';
+interface LocaleSeparators {
+  decimalSeparator: string;
+  groupingSeparator: string;
+}
 
 @Injectable({
   providedIn: 'root',
@@ -26,9 +29,13 @@ export class NumberFormatService {
   static readonly DEFAULT_DECIMAL_PLACES = 2;
   static readonly DEFAULT_AUTOFILL_DECIMALS = false;
   static readonly DEFAULT_REMOVE_LEADING_ZEROS = false;
+  private static readonly DEFAULT_LOCALE_SEPARATORS: LocaleSeparators = {
+    decimalSeparator: '.',
+    groupingSeparator: ',',
+  };
 
-  decimalSeparator: NumericSeparator;
-  groupingSeparator: NumericSeparator;
+  decimalSeparator: string;
+  groupingSeparator: string;
 
   allowedKeys: string[] = [];
 
@@ -45,7 +52,7 @@ export class NumberFormatService {
    * @param locale the new locale
    */
   prepareSeparators(locale: string): void {
-    const separators = this.getSeparators(locale);
+    const separators = this.resolveLocaleSeparators(locale);
     this.decimalSeparator = separators.decimalSeparator;
     this.groupingSeparator = separators.groupingSeparator;
 
@@ -146,21 +153,27 @@ export class NumberFormatService {
     return result;
   }
 
-  private getSeparators(locale: string): {
-    decimalSeparator: NumericSeparator;
-    groupingSeparator: NumericSeparator;
-  } {
-    if (locale === 'de-DE' || locale === 'de-AT' || locale === 'de') {
-      return {
-        decimalSeparator: ',',
-        groupingSeparator: '.',
-      };
+  private resolveLocaleSeparators(locale: string): LocaleSeparators {
+    try {
+      if (Intl.NumberFormat.supportedLocalesOf(locale).length === 0) {
+        return NumberFormatService.DEFAULT_LOCALE_SEPARATORS;
+      }
+
+      const parts = Intl.NumberFormat(locale).formatToParts(1234.5);
+      const decimalSeparator = parts.find((part) => part.type === 'decimal')?.value;
+      const groupingSeparator = parts.find((part) => part.type === 'group')?.value;
+
+      if (decimalSeparator && groupingSeparator) {
+        return {
+          decimalSeparator,
+          groupingSeparator,
+        };
+      }
+    } catch {
+      return NumberFormatService.DEFAULT_LOCALE_SEPARATORS;
     }
 
-    return {
-      decimalSeparator: '.',
-      groupingSeparator: ',',
-    };
+    return NumberFormatService.DEFAULT_LOCALE_SEPARATORS;
   }
 
   private addMissingLeadingZero(result: string, actualDecimalIndex: number): string {

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
@@ -1,126 +1,259 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NumericFieldDirective } from './numeric-field.directive';
-import { FormsModule } from '@angular/forms';
 import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { NumberFormatService } from './number-format.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import { NumericFieldModule } from './numeric-field.module';
+import { NumericFieldDirective } from './numeric-field.directive';
 
 @Component({
-  template: ` <input data-testid="simple" matInput unit="kg" [(ngModel)]="value" madNumericField />
-    <input data-testid="rightUnit" matInput unit="kg" unitPosition="right" textAlign="left" [(ngModel)]="value" madNumericField />
-    <input data-testid="leftUnit" matInput unit="kg" unitPosition="left" textAlign="left" [(ngModel)]="value" madNumericField />`,
-  imports: [NumericFieldModule, FormsModule],
+  template: `
+    <mat-form-field>
+      <input data-testid="simple" matInput [(ngModel)]="value" madNumericField />
+    </mat-form-field>
+
+    <mat-form-field>
+      <input data-testid="reactiveInitialValue" matInput [formControl]="reactiveInitialValue" unit="EUR" madNumericField />
+    </mat-form-field>
+
+    <mat-form-field>
+      <input
+        data-testid="numericValueInitialValue"
+        matInput
+        [numericValue]="numericValueInitialValue"
+        (numericValueChange)="numericValueInitialValue = $event"
+        unit="EUR"
+        madNumericField
+      />
+    </mat-form-field>
+
+    <mat-form-field>
+      <input data-testid="rightUnit" matInput unit="kg" unitPosition="right" textAlign="left" [(ngModel)]="value" madNumericField />
+    </mat-form-field>
+
+    <mat-form-field>
+      <input data-testid="leftUnit" matInput unit="kg" unitPosition="left" textAlign="left" [(ngModel)]="value" madNumericField />
+    </mat-form-field>
+
+    <mat-form-field>
+      <input data-testid="money" matInput [autofillDecimals]="true" [(ngModel)]="moneyValue" madNumericField />
+    </mat-form-field>
+
+    <mat-form-field>
+      <input data-testid="integer" matInput decimalPlaces="0" [(ngModel)]="integerValue" madNumericField />
+    </mat-form-field>
+
+    <mat-form-field>
+      <input data-testid="rounded" matInput [roundDisplayValue]="true" [(ngModel)]="roundedValue" madNumericField />
+    </mat-form-field>
+  `,
+  imports: [NumericFieldModule, FormsModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule],
 })
 class TestComponent {
-  public value: number;
+  value?: number;
+  reactiveInitialValue = new FormControl<number | null | undefined>(1234.56);
+  numericValueInitialValue: number | null | undefined = 1234.56;
+  moneyValue?: number;
+  integerValue?: number;
+  roundedValue?: number;
 }
 
 describe('NumericFieldDirective', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
-  let simpleInputEl: DebugElement;
-  let rightUnitInputEl: DebugElement;
-  let leftUnitInputEl: DebugElement;
-  let simpleInputDirective: NumericFieldDirective;
-  let rightUnitInputDirective: NumericFieldDirective;
-  let leftUnitInputDirective: NumericFieldDirective;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestComponent, NoopAnimationsModule],
-      providers: [NumberFormatService],
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
-    simpleInputEl = fixture.debugElement.query(By.css('[data-testid="simple"]'));
-    simpleInputDirective = simpleInputEl.injector.get(NumericFieldDirective);
-    rightUnitInputEl = fixture.debugElement.query(By.css('[data-testid="rightUnit"]'));
-    Object.defineProperty(rightUnitInputEl.nativeElement, 'offsetWidth', { value: 100, writable: true });
-    rightUnitInputDirective = rightUnitInputEl.injector.get(NumericFieldDirective);
-    leftUnitInputEl = fixture.debugElement.query(By.css('[data-testid="leftUnit"]'));
-    Object.defineProperty(leftUnitInputEl.nativeElement, 'offsetWidth', { value: 100, writable: true });
-    leftUnitInputDirective = leftUnitInputEl.injector.get(NumericFieldDirective);
     fixture.detectChanges();
   });
 
   it('should create an instance', () => {
-    expect(simpleInputDirective).not.toBeNull();
+    expect(getDirective('simple')).toBeTruthy();
   });
 
-  it('Should update numericValue on input change', () => {
-    simpleInputEl.nativeElement.value = '123.456';
-    simpleInputEl.nativeElement.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    expect(component.value).toEqual(123.45);
-    expect(simpleInputDirective.unit).toEqual('kg');
-  });
+  it('should set default params properly', () => {
+    const debugElement = getDebugElement('simple');
+    const input = getInput('simple');
+    const directive = debugElement.injector.get(NumericFieldDirective);
 
-  it('Should set default params properly', () => {
-    simpleInputEl.nativeElement.dispatchEvent(new Event('input'));
-
-    expect(simpleInputEl.classes['text-right']).toBeTruthy();
-    expect(simpleInputDirective.textAlign).toEqual('right');
-    expect(simpleInputDirective.decimalPlaces).toEqual(2);
-    expect(simpleInputDirective.roundValue).toBeFalsy();
-    expect(simpleInputDirective.autofillDecimals).toBeFalsy();
-    expect(simpleInputDirective.unitPosition).toEqual('right');
-  });
-
-  it('Should set unitPosition to right and textAlign to left and inject unitSpan', () => {
-    rightUnitInputEl.nativeElement.value = '123.456';
-    rightUnitInputEl.nativeElement.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    expect(rightUnitInputDirective.unit).toEqual('kg');
-    expect(rightUnitInputDirective.unitPosition).toEqual('right');
-  });
-
-  it('Should set unitPosition to left and textAlign to left and inject unitSpan', () => {
-    leftUnitInputEl.nativeElement.value = '123.456';
-    leftUnitInputEl.nativeElement.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
-    expect(leftUnitInputDirective.unit).toEqual('kg');
-    expect(leftUnitInputDirective.unitPosition).toEqual('left');
-  });
-
-  it('Should fire keydown backspace event', () => {
-    leftUnitInputEl.nativeElement.value = '123456,';
-    let event = new KeyboardEvent('keydown', { keyCode: 8 });
-    leftUnitInputEl.nativeElement.dispatchEvent(event);
+    input.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
-    expect(leftUnitInputEl.nativeElement.value).toEqual('12345,');
+    expect(debugElement.classes['text-right']).toBeTruthy();
+    expect(directive.textAlign()).toEqual('right');
+    expect(directive.decimalPlaces()).toEqual(2);
+    expect(directive.roundValue()).toBeFalsy();
+    expect(directive.autofillDecimals()).toBeFalsy();
+    expect(directive.unitPosition()).toEqual('right');
   });
 
-  it('Should fire keydown delete event', () => {
-    leftUnitInputEl.nativeElement.value = '123,56';
-    let event = new KeyboardEvent('keydown', { keyCode: 46 });
-    Object.defineProperty(leftUnitInputEl.nativeElement, 'selectionStart', { get: () => 3 });
-    Object.defineProperty(leftUnitInputEl.nativeElement, 'selectionEnd', { get: () => 3 });
-    leftUnitInputEl.nativeElement.dispatchEvent(event);
+  it('should update form value and format display value on input', () => {
+    const input = getInput('simple');
+
+    setInputValue(input, '1234.567');
+
+    expect(component.value).toEqual(1234.56);
+    expect(input.value).toEqual('1,234.56');
+  });
+
+  it('should format initial reactive form values', () => {
+    expect(getInput('reactiveInitialValue').value).toEqual('1,234.56');
+  });
+
+  it('should format initial numericValue input values', () => {
+    expect(getInput('numericValueInitialValue').value).toEqual('1,234.56');
+  });
+
+  it('should return undefined for an empty value to support required validators', () => {
+    const input = getInput('simple');
+
+    setInputValue(input, '');
+
+    expect(component.value).toBeUndefined();
+  });
+
+  it('should apply final formatting on blur', () => {
+    const input = getInput('money');
+
+    setInputValue(input, '12');
+    input.dispatchEvent(new Event('blur'));
     fixture.detectChanges();
 
-    expect(leftUnitInputEl.nativeElement.value).toEqual('123,6');
+    expect(component.moneyValue).toEqual(12);
+    expect(input.value).toEqual('12.00');
   });
 
-  it('Should fire keyup backspace event', () => {
-    leftUnitInputEl.nativeElement.value = '123456,';
-    let event = new KeyboardEvent('keyup', { keyCode: 8 });
-    leftUnitInputEl.nativeElement.dispatchEvent(event);
+  it('should round display value when roundDisplayValue is enabled', () => {
+    const input = getInput('rounded');
+
+    getDirective('rounded').writeValue(1234.567);
     fixture.detectChanges();
 
-    expect(leftUnitInputEl.nativeElement.value).toEqual('123,456');
+    expect(input.value).toEqual('1,234.57');
   });
 
-  it('Should fire keyup backspace event', () => {
-    leftUnitInputEl.nativeElement.value = '123456,';
-    leftUnitInputEl.nativeElement.dispatchEvent(new Event('blur'));
+  it('should truncate display value by default', () => {
+    const input = getInput('simple');
+
+    getDirective('simple').writeValue(1234.567);
     fixture.detectChanges();
 
-    expect(leftUnitInputEl.nativeElement.value).toEqual('123,456');
+    expect(input.value).toEqual('1,234.56');
   });
+
+  it('should prevent invalid characters', () => {
+    const input = getInput('simple');
+    const event = new KeyboardEvent('keydown', { key: 'a', cancelable: true });
+
+    const result = input.dispatchEvent(event);
+
+    expect(result).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should prevent decimal separators when decimalPlaces is zero', () => {
+    const input = getInput('integer');
+    const event = new KeyboardEvent('keydown', { key: '.', cancelable: true });
+
+    const result = input.dispatchEvent(event);
+
+    expect(result).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should prevent too many decimal places', () => {
+    const input = getInput('simple');
+    input.value = '123.45';
+    input.setSelectionRange(6, 6);
+    const event = new KeyboardEvent('keydown', { key: '6', cancelable: true });
+
+    const result = input.dispatchEvent(event);
+
+    expect(result).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should allow a negative sign only at the beginning', () => {
+    const input = getInput('simple');
+    const allowedEvent = new KeyboardEvent('keydown', { key: '-', cancelable: true });
+
+    input.value = '123';
+    input.setSelectionRange(0, 0);
+    expect(input.dispatchEvent(allowedEvent)).toBe(true);
+    expect(allowedEvent.defaultPrevented).toBe(false);
+
+    const blockedEvent = new KeyboardEvent('keydown', { key: '-', cancelable: true });
+    input.value = '123';
+    input.setSelectionRange(1, 1);
+    expect(input.dispatchEvent(blockedEvent)).toBe(false);
+    expect(blockedEvent.defaultPrevented).toBe(true);
+  });
+
+  it('should remove adjacent digit when deleting a grouping separator', () => {
+    const input = getInput('simple');
+    input.value = '123,456';
+    input.setSelectionRange(3, 3);
+    const event = new KeyboardEvent('keydown', { key: 'Delete', cancelable: true });
+
+    input.dispatchEvent(event);
+    fixture.detectChanges();
+
+    expect(input.value).toEqual('123,56');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should implement disabled state', () => {
+    const input = getInput('simple');
+    const directive = getDirective('simple');
+
+    directive.setDisabledState(true);
+
+    expect(input.disabled).toBe(true);
+  });
+
+  it('should render a left-positioned unit compatibility span', () => {
+    const input = getInput('leftUnit');
+    const unit = input.closest('mat-form-field')?.querySelector('.mad-numeric-field-unit');
+
+    expect(unit?.textContent).toEqual('kg');
+    expect(unit?.hasAttribute('matprefix')).toBe(true);
+    expect(unit?.hasAttribute('mattextprefix')).toBe(true);
+  });
+
+  it('should render a right-positioned unit compatibility span', () => {
+    const input = getInput('rightUnit');
+    const unit = input.closest('mat-form-field')?.querySelector('.mad-numeric-field-unit');
+
+    expect(unit?.textContent).toEqual('kg');
+    expect(unit?.hasAttribute('matsuffix')).toBe(true);
+    expect(unit?.hasAttribute('mattextsuffix')).toBe(true);
+  });
+
+  function getDebugElement(testId: string): DebugElement {
+    return fixture.debugElement.query(By.css(`[data-testid="${testId}"]`));
+  }
+
+  function getInput(testId: string): HTMLInputElement {
+    return getDebugElement(testId).nativeElement as HTMLInputElement;
+  }
+
+  function getDirective(testId: string): NumericFieldDirective {
+    return getDebugElement(testId).injector.get(NumericFieldDirective);
+  }
+
+  function setInputValue(input: HTMLInputElement, value: string): void {
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+  }
 });

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
@@ -18,6 +18,7 @@ import { NumericFieldDirective } from './numeric-field.directive';
     <input data-testid="plain" [numericValue]="plainValue" (numericValueChange)="plainValue = $event" madNumericField />
 
     <mat-form-field>
+      <mat-label>Reactive initial value</mat-label>
       <input data-testid="reactiveInitialValue" matInput [formControl]="reactiveInitialValue" unit="EUR" madNumericField />
     </mat-form-field>
 
@@ -111,6 +112,39 @@ describe('NumericFieldDirective', () => {
 
   it('should format initial reactive form values', () => {
     expect(getInput('reactiveInitialValue').value).toEqual('1,234.56');
+  });
+
+  it('should apply reactive form disabled state through ControlValueAccessor', () => {
+    const input = getInput('reactiveInitialValue');
+
+    expect(input.disabled).toBe(false);
+
+    component.reactiveInitialValue.disable();
+    fixture.detectChanges();
+
+    expect(input.disabled).toBe(true);
+
+    component.reactiveInitialValue.enable();
+    fixture.detectChanges();
+
+    expect(input.disabled).toBe(false);
+  });
+
+  it('should clear the input when a reactive form control is reset', () => {
+    const input = getInput('reactiveInitialValue');
+
+    component.reactiveInitialValue.reset();
+    fixture.detectChanges();
+
+    expect(input.value).toBe('');
+    expect(component.reactiveInitialValue.value).toBeNull();
+  });
+
+  it('should float the Material label for initial reactive form values', () => {
+    const formField = getInput('reactiveInitialValue').closest('mat-form-field');
+    const label = formField?.querySelector('.mdc-floating-label');
+
+    expect(label?.classList.contains('mdc-floating-label--float-above')).toBe(true);
   });
 
   it('should format initial numericValue input values', () => {

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.spec.ts
@@ -4,8 +4,8 @@ import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import { MatInput, MatInputModule } from '@angular/material/input';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { NumericFieldModule } from './numeric-field.module';
 import { NumericFieldDirective } from './numeric-field.directive';
 
@@ -14,6 +14,8 @@ import { NumericFieldDirective } from './numeric-field.directive';
     <mat-form-field>
       <input data-testid="simple" matInput [(ngModel)]="value" madNumericField />
     </mat-form-field>
+
+    <input data-testid="plain" [numericValue]="plainValue" (numericValueChange)="plainValue = $event" madNumericField />
 
     <mat-form-field>
       <input data-testid="reactiveInitialValue" matInput [formControl]="reactiveInitialValue" unit="EUR" madNumericField />
@@ -54,6 +56,7 @@ import { NumericFieldDirective } from './numeric-field.directive';
 })
 class TestComponent {
   value?: number;
+  plainValue: number | null | undefined = 1234.56;
   reactiveInitialValue = new FormControl<number | null | undefined>(1234.56);
   numericValueInitialValue: number | null | undefined = 1234.56;
   moneyValue?: number;
@@ -112,6 +115,21 @@ describe('NumericFieldDirective', () => {
 
   it('should format initial numericValue input values', () => {
     expect(getInput('numericValueInitialValue').value).toEqual('1,234.56');
+  });
+
+  it('should notify MatInput when writing the native input value manually', () => {
+    const debugElement = getDebugElement('simple');
+    const matInput = debugElement.injector.get(MatInput);
+    const stateChangesSpy = jest.spyOn(matInput.stateChanges, 'next');
+
+    getDirective('simple').writeValue(1234.56);
+
+    expect(getInput('simple').value).toEqual('1,234.56');
+    expect(stateChangesSpy).toHaveBeenCalled();
+  });
+
+  it('should work without matInput', () => {
+    expect(getInput('plain').value).toEqual('1,234.56');
   });
 
   it('should return undefined for an empty value to support required validators', () => {

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
@@ -5,33 +5,51 @@
  */
 
 import {
-  AfterViewChecked,
+  AfterViewInit,
+  booleanAttribute,
   Directive,
   ElementRef,
-  EventEmitter,
+  effect,
   forwardRef,
-  Input,
+  inject,
+  input,
+  numberAttribute,
   OnDestroy,
-  OnInit,
-  Output,
+  output,
   Renderer2,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NumberFormatService } from './number-format.service';
 
-const BACK_KEYCODE = 8;
-const SPACE_KEYCODE = 32;
-const DEL_KEYCODE = 46;
-const CONTROL_KEYCODES_UPPER_BORDER = 46;
-const OTHER_CONTROL_KEYS = new Set([224, 91, 93]);
+const CONTROL_KEYS = new Set([
+  'Backspace',
+  'Delete',
+  'Tab',
+  'Escape',
+  'Enter',
+  'Home',
+  'End',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+]);
+
+type UnitPosition = 'right' | 'left';
+type NumericValue = number | null | undefined;
+
+const UNSET_NUMERIC_VALUE = Symbol('unset numeric value input');
+type NumericValueInput = NumericValue | typeof UNSET_NUMERIC_VALUE;
 
 @Directive({
   selector: '[madNumericField]',
   host: {
-    '[class.text-right]': 'textAlign === "right"',
-    '(change)': 'onChange(getValueForFormControl())',
-    '(input)': 'onChange(getValueForFormControl())',
-    '(blur)': 'onTouched()',
+    '[class.text-right]': 'textAlign() === "right"',
+    '(change)': 'handleChangeEvent()',
+    '(input)': 'handleInputEvent()',
+    '(blur)': 'handleBlurEvent()',
+    '(keydown)': 'handleKeyDown($event)',
+    '(keyup)': 'handleKeyUp($event)',
   },
   providers: [
     {
@@ -42,285 +60,457 @@ const OTHER_CONTROL_KEYS = new Set([224, 91, 93]);
   ],
   standalone: true,
 })
-export class NumericFieldDirective implements OnInit, OnDestroy, AfterViewChecked, ControlValueAccessor {
-  @Input('textAlign') textAlign: 'right' | 'left' = 'right';
-  @Input('decimalPlaces') decimalPlaces = 2;
-  @Input('roundDisplayValue') roundValue = false;
-  @Input('autofillDecimals') autofillDecimals = false;
-  @Input('unit') unit: string | null = null;
-  @Input('unitPosition') unitPosition: 'right' | 'left' = 'right';
-  @Output('numericValueChange') numericValueChanged = new EventEmitter<number>();
+export class NumericFieldDirective implements AfterViewInit, OnDestroy, ControlValueAccessor {
+  readonly textAlign = input<UnitPosition>('right', { alias: 'textAlign' });
+  readonly decimalPlaces = input(NumberFormatService.DEFAULT_DECIMAL_PLACES, {
+    alias: 'decimalPlaces',
+    transform: (value: unknown) => numberAttribute(value, NumberFormatService.DEFAULT_DECIMAL_PLACES),
+  });
+  readonly roundValue = input(false, { alias: 'roundDisplayValue', transform: booleanAttribute });
+  readonly autofillDecimals = input(false, { alias: 'autofillDecimals', transform: booleanAttribute });
+  readonly unit = input<string | null>(null, { alias: 'unit' });
+  readonly unitPosition = input<UnitPosition>('right', { alias: 'unitPosition' });
+  readonly numericValue = input<NumericValueInput, NumericValue>(UNSET_NUMERIC_VALUE, {
+    alias: 'numericValue',
+    transform: (value) => value,
+  });
+  readonly numericValueChanged = output<number>({ alias: 'numericValueChange' });
+
+  private readonly renderer = inject(Renderer2);
+  private readonly inputEl = inject<ElementRef<HTMLInputElement>>(ElementRef);
+  private readonly numberFormatService = inject(NumberFormatService);
 
   private displayValue = '';
-  private originalValue = NaN;
-  private _numericValue: number;
-  private inputChangeListener: () => void;
-  private keyupListener: () => void;
-  private keydownListener: () => void;
+  private originalValue: NumericValue = NaN;
+  private numericValueInternal: NumericValue;
+  private textSpan?: HTMLSpanElement;
+  private unitSpan?: HTMLSpanElement;
+  private unitSpanPosition?: UnitPosition;
+  private viewInitialized = false;
+  private formatOptionsInitialized = false;
+  private changeFn?: (value: number | undefined) => void;
+  private touchedFn?: () => void;
+  private readonly numericValueEffect = effect(() => {
+    const value = this.numericValue();
 
-  @Input('numericValue')
-  set numericValue(value: number) {
-    if (this._numericValue !== value && !(isNaN(this._numericValue) && (isNaN(value) || value === null))) {
-      this.originalValue = value;
-      // Don't roundOrTruncate if value was set to empty otherwise input value will be set to 0 instead of empty
-      // which happens when an input is being reset
-      this._numericValue = value === null || value === undefined ? value : this.roundOrTruncate(value); // eslint-disable-line
-      this.handleInputChanged();
+    if (value !== UNSET_NUMERIC_VALUE) {
+      this.applyExternalValue(value);
     }
+  });
+  private readonly formatOptionsEffect = effect(() => {
+    this.decimalPlaces();
+    this.autofillDecimals();
+    this.roundValue();
+
+    if (this.formatOptionsInitialized) {
+      this.handleInputChanged();
+    } else {
+      this.formatOptionsInitialized = true;
+    }
+  });
+  private readonly unitEffect = effect(() => {
+    this.unit();
+    this.unitPosition();
+    this.textAlign();
+
+    this.syncUnitSymbol();
+  });
+
+  private get inputElement(): HTMLInputElement {
+    return this.inputEl.nativeElement;
   }
 
-  private unitSpan: HTMLSpanElement;
-  private textSpan: HTMLSpanElement;
-
-  constructor(
-    private renderer: Renderer2,
-    private inputEl: ElementRef,
-    private numberFormatService: NumberFormatService,
-  ) {}
-
-  /* Control Values Accessor Stuff below */
-  // eslint-disable-next-line
-  onChange: any = () => {};
-  // eslint-disable-next-line
-  onTouched: any = () => {};
-
-  registerOnChange(fn: any): void {
-    this.onChange = fn;
+  registerOnChange(fn: (value: number | undefined) => void): void {
+    this.changeFn = fn;
   }
 
-  registerOnTouched(fn: any): void {
-    this.onTouched = fn;
+  registerOnTouched(fn: () => void): void {
+    this.touchedFn = fn;
   }
 
-  setDisabledState(): void {
-    // Dont need to implement since its just a directive
+  setDisabledState(isDisabled: boolean): void {
+    this.renderer.setProperty(this.inputElement, 'disabled', isDisabled);
   }
 
-  writeValue(value: number): void {
-    this.numericValue = value;
+  writeValue(value: NumericValue): void {
+    this.applyExternalValue(value);
   }
 
-  ngOnInit(): void {
-    /* needs to be parsed as number explicitly as it comes as string from user input */
-    this.decimalPlaces = parseInt(this.decimalPlaces.toString(), 10);
-
-    this.inputChangeListener = this.renderer.listen(this.inputEl.nativeElement, 'blur', (event) => {
-      this.formatInput(event.target, true);
-    });
-
-    this.keyupListener = this.renderer.listen(this.inputEl.nativeElement, 'keyup', (event) => {
-      if (event.keyCode === BACK_KEYCODE || (event.keyCode >= CONTROL_KEYCODES_UPPER_BORDER && !OTHER_CONTROL_KEYS.has(event.keyCode))) {
-        this.formatInput(event.target, false);
-      }
-    });
-
-    this.keydownListener = this.renderer.listen(this.inputEl.nativeElement, 'keydown', (event) => {
-      const value: string = event.target.value;
-      if (
-        this.numberFormatService.allowedKeys.includes(event.key) ||
-        (event.keyCode <= CONTROL_KEYCODES_UPPER_BORDER && event.keyCode > 0 && event.keyCode !== SPACE_KEYCODE) ||
-        event.metaKey ||
-        event.ctrlKey ||
-        event.altKey
-      ) {
-        /* allow negative sign only as first character and none exists outside of text selection */
-        const indexNegativeSign = value.indexOf(NumberFormatService.NEGATIVE);
-        if (
-          event.key === NumberFormatService.NEGATIVE &&
-          (event.target.selectionStart > 0 || indexNegativeSign > -1) &&
-          (event.target.selectionStart === event.target.selectionEnd ||
-            !(indexNegativeSign >= event.target.selectionStart && indexNegativeSign <= event.target.selectionEnd))
-        ) {
-          return false;
-        }
-
-        /* no duplicate decimal separators */
-        const indexDecimalSep = value.indexOf(this.numberFormatService.decimalSeparator);
-        if (
-          event.key === this.numberFormatService.decimalSeparator &&
-          (indexDecimalSep > -1 || this.decimalPlaces === 0) &&
-          (event.target.selectionStart === event.target.selectionEnd ||
-            !(indexDecimalSep >= event.target.selectionStart && indexDecimalSep <= event.target.selectionEnd))
-        ) {
-          return false;
-        }
-
-        /* prevent too many decimal places */
-        if (
-          NumberFormatService.NUMBERS.includes(event.key) &&
-          indexDecimalSep > -1 &&
-          indexDecimalSep < event.target.selectionStart &&
-          event.target.selectionStart === event.target.selectionEnd &&
-          value.length > indexDecimalSep + this.decimalPlaces
-        ) {
-          return false;
-        }
-
-        /* when deleting thousand separator, remove the digit before or after it */
-        const cursorStart = event.target.selectionStart;
-
-        if (cursorStart === event.target.selectionEnd) {
-          if (event.keyCode === BACK_KEYCODE && value.substr(cursorStart - 1, 1) === this.numberFormatService.groupingSeparator) {
-            event.target.value = value.substring(0, cursorStart - 2) + value.substring(cursorStart - 1, value.length);
-            event.target.selectionStart = event.target.selectionEnd = cursorStart - 1;
-            return false;
-          } else if (event.keyCode === DEL_KEYCODE && value.substr(cursorStart, 1) === this.numberFormatService.groupingSeparator) {
-            event.target.value = value.substring(0, cursorStart + 1) + value.substring(cursorStart + 2, value.length);
-            event.target.selectionStart = event.target.selectionEnd = cursorStart + 1;
-            return false;
-          }
-        }
-        this.originalValue = NaN;
-      } else {
-        return false;
-      }
-      return true;
-    });
+  ngAfterViewInit(): void {
+    this.viewInitialized = true;
+    this.syncUnitSymbol();
   }
 
   ngOnDestroy(): void {
-    this.detachListener();
+    this.removeUnitSpan();
+    this.removeTextSpan();
   }
 
-  ngAfterViewChecked(): void {
-    // Only needed to create the unitSpan or refresh the unit
-    if (!this.unitSpan || this.unitSpan.textContent !== this.unit) {
-      this.injectUnitSymbol();
+  handleChangeEvent(): void {
+    this.changeFn?.(this.getValueForFormControl());
+  }
+
+  handleInputEvent(): void {
+    this.changeFn?.(this.getValueForFormControl());
+  }
+
+  handleBlurEvent(): void {
+    this.formatInput(this.inputElement, true);
+    this.touchedFn?.();
+  }
+
+  handleKeyDown(event: KeyboardEvent): boolean {
+    const element = this.getEventInput(event);
+    const value = element.value;
+
+    if (event.metaKey || event.ctrlKey || event.altKey || CONTROL_KEYS.has(event.key)) {
+      return this.handleControlKeyDown(event, element, value);
     }
+
+    if (!this.numberFormatService.allowedKeys.includes(event.key)) {
+      return this.preventDefault(event);
+    }
+
+    if (!this.isValidNegativeSign(event, element, value)) {
+      return this.preventDefault(event);
+    }
+
+    if (!this.isValidDecimalSeparator(event, element, value)) {
+      return this.preventDefault(event);
+    }
+
+    if (!this.isValidDecimalPlace(event, element, value)) {
+      return this.preventDefault(event);
+    }
+
+    this.originalValue = NaN;
+    return true;
   }
 
-  handleInputChanged(): void {
-    // Call in set timeout to avoid Expression has changed after it has been checked error.
-    // Sometimes the value changes because we cut off decimal places
-    setTimeout(() => {
-      this.updateInput(
-        this.numberFormatService.format(this._numericValue, {
-          decimalPlaces: this.decimalPlaces,
-          finalFormatting: true,
-          autofillDecimals: this.autofillDecimals,
-        }),
-      );
-    }, 1);
+  handleKeyUp(event: KeyboardEvent): void {
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+
+    if (event.key === 'Backspace' || event.key === 'Delete' || this.numberFormatService.allowedKeys.includes(event.key)) {
+      this.formatInput(this.getEventInput(event), false);
+    }
   }
 
   formatInput(element: HTMLInputElement, finalFormatting: boolean): void {
-    const cursorPos = element.selectionStart;
+    const cursorPos = element.selectionStart ?? element.value.length;
     const length = element.value.length;
     const setCursor = this.displayValue !== element.value;
     const textFormatted = this.numberFormatService.formatNumber(element.value, {
-      decimalPlaces: this.decimalPlaces,
+      decimalPlaces: this.decimalPlaces(),
       finalFormatting,
-      autofillDecimals: this.autofillDecimals,
+      autofillDecimals: this.autofillDecimals(),
     });
 
-    // special handling to move unit symbol along with display value
-    if (this.textAlign === 'left' && this.unitPosition === 'right') {
-      const inputStyles = window.getComputedStyle(this.inputEl.nativeElement.parentElement, null);
-      this.unitSpan.style.position = 'absolute';
-      this.unitSpan.style.marginTop = inputStyles.getPropertyValue('border-top-width');
-      this.unitSpan.style.paddingTop = inputStyles.getPropertyValue('padding-top');
-      this.unitSpan.style.paddingBottom = inputStyles.getPropertyValue('padding-bottom');
-
-      if (!this.textSpan) {
-        this.textSpan = document.createElement('span');
-        document.body.appendChild(this.textSpan);
-        this.textSpan.style.font = inputStyles.getPropertyValue('font');
-        this.textSpan.style.fontSize = inputStyles.getPropertyValue('font-size');
-        this.textSpan.style.height = 'auto';
-        this.textSpan.style.width = 'auto';
-        this.textSpan.style.position = 'absolute';
-        this.textSpan.style.top = '0';
-        this.textSpan.style.whiteSpace = 'no-wrap';
-        this.textSpan.style.visibility = 'hidden';
-      }
-      this.textSpan.innerHTML = textFormatted;
-      const width = Math.min(this.inputEl.nativeElement.clientWidth - this.unitSpan.clientWidth, Math.ceil(this.textSpan.clientWidth));
-      this.unitSpan.style.left = width + 'px';
-    }
-
     this.updateInput(textFormatted);
+    this.updateTrailingUnitPosition(textFormatted);
+
     if (setCursor) {
-      element.selectionStart = element.selectionEnd = Math.max(cursorPos + element.value.length - length, 0);
+      this.setCursorPosition(element, Math.max(cursorPos + element.value.length - length, 0));
     }
   }
 
   updateInput(value: string): void {
     this.displayValue = value;
-    this.inputEl.nativeElement.value = value;
-    this._numericValue = parseFloat(
-      this.numberFormatService.strip(value, { decimalPlaces: this.decimalPlaces }).replace(this.numberFormatService.decimalSeparator, '.'),
-    );
-    if (this._numericValue !== this.roundOrTruncate(this.originalValue)) {
-      this.originalValue = this._numericValue;
-      this.numericValueChanged.emit(this._numericValue);
+    this.inputElement.value = value;
+    this.numericValueInternal = this.parseNumericValue(value);
+
+    if (this.numericValueInternal !== this.getComparableOriginalValue()) {
+      this.originalValue = this.numericValueInternal;
+      this.numericValueChanged.emit(this.numericValueInternal);
     }
+
+    this.syncUnitSymbol();
   }
 
   getValueForFormControl(): number | undefined {
-    this.formatInput(this.inputEl.nativeElement, false);
-    if (isNaN(this._numericValue)) {
-      // Return undefined instead of NaN to support the default required validator.
-      return undefined; // eslint-disable-line
+    this.formatInput(this.inputElement, false);
+
+    if (typeof this.numericValueInternal !== 'number' || Number.isNaN(this.numericValueInternal)) {
+      return undefined;
     }
-    return this._numericValue;
+
+    return this.numericValueInternal;
+  }
+  private handleInputChanged(): void {
+    this.updateInput(
+      this.numberFormatService.format(this.numericValueInternal, {
+        decimalPlaces: this.decimalPlaces(),
+        finalFormatting: true,
+        autofillDecimals: this.autofillDecimals(),
+      }),
+    );
   }
 
-  private injectUnitSymbol(): void {
-    // Need to inject the unit symbol when the input element width is set to its actual value,
-    // otherwise the icon wont show in the correct position
-    if (!!this.unit && !this.unitSpan && this.inputEl.nativeElement.offsetWidth !== 0) {
-      // Get the input wrapper and apply necessary styles
-      const inputWrapper = this.inputEl.nativeElement.parentNode.parentNode;
-
-      // Create the span with unit symbol and apply necessary styles
-      this.unitSpan = this.renderer.createElement('span');
-
-      if (this.unitPosition === 'left') {
-        this.renderer.setAttribute(this.unitSpan, 'matPrefix', '');
-        this.renderer.setStyle(this.unitSpan, 'padding-right', '5px');
-        this.renderer.insertBefore(inputWrapper, this.unitSpan, inputWrapper.children[0]);
-      } else {
-        this.renderer.setAttribute(this.unitSpan, 'matSuffix', '');
-        this.renderer.setStyle(this.unitSpan, 'padding-left', '5px');
-        this.renderer.appendChild(inputWrapper, this.unitSpan);
-      }
+  private applyExternalValue(value: NumericValue): void {
+    if (
+      this.numericValueInternal === value ||
+      (this.isEmptyNumericValue(this.numericValueInternal) && (this.isEmptyNumericValue(value) || value === null))
+    ) {
+      return;
     }
 
-    // do not display unit symbol if the unit should move along display value
-    if (!!this.unitSpan && this.textAlign === 'left' && this.unitPosition === 'right') {
-      if (NumberFormatService.valueIsSet(this.displayValue)) {
-        this.unitSpan.style.display = 'unset';
-      } else {
-        this.unitSpan.style.display = 'none';
-      }
+    this.originalValue = value;
+    this.numericValueInternal = value === null || value === undefined ? value : this.roundOrTruncate(value);
+    this.handleInputChanged();
+  }
+
+  private handleControlKeyDown(event: KeyboardEvent, element: HTMLInputElement, value: string): boolean {
+    if (event.key !== 'Backspace' && event.key !== 'Delete') {
+      return true;
     }
-    // always reset unit symbol
-    if (!!this.unitSpan) {
-      this.unitSpan.textContent = this.unit;
+
+    const cursorStart = element.selectionStart ?? 0;
+    const cursorEnd = element.selectionEnd ?? cursorStart;
+
+    if (cursorStart !== cursorEnd) {
+      return true;
+    }
+
+    if (event.key === 'Backspace' && value.charAt(cursorStart - 1) === this.numberFormatService.groupingSeparator) {
+      element.value = value.substring(0, Math.max(cursorStart - 2, 0)) + value.substring(cursorStart - 1, value.length);
+      this.setCursorPosition(element, Math.max(cursorStart - 1, 0));
+      this.updateInput(element.value);
+      return this.preventDefault(event);
+    }
+
+    if (event.key === 'Delete' && value.charAt(cursorStart) === this.numberFormatService.groupingSeparator) {
+      element.value = value.substring(0, cursorStart + 1) + value.substring(cursorStart + 2, value.length);
+      this.setCursorPosition(element, cursorStart + 1);
+      this.updateInput(element.value);
+      return this.preventDefault(event);
+    }
+
+    return true;
+  }
+
+  private isValidNegativeSign(event: KeyboardEvent, element: HTMLInputElement, value: string): boolean {
+    if (event.key !== NumberFormatService.NEGATIVE) {
+      return true;
+    }
+
+    const selectionStart = element.selectionStart ?? 0;
+    const selectionEnd = element.selectionEnd ?? selectionStart;
+    const indexNegativeSign = value.indexOf(NumberFormatService.NEGATIVE);
+
+    return (
+      selectionStart === 0 &&
+      (indexNegativeSign === -1 ||
+        (selectionStart !== selectionEnd && indexNegativeSign >= selectionStart && indexNegativeSign <= selectionEnd))
+    );
+  }
+
+  private isValidDecimalSeparator(event: KeyboardEvent, element: HTMLInputElement, value: string): boolean {
+    if (event.key !== this.numberFormatService.decimalSeparator) {
+      return true;
+    }
+
+    const selectionStart = element.selectionStart ?? 0;
+    const selectionEnd = element.selectionEnd ?? selectionStart;
+    const indexDecimalSep = value.indexOf(this.numberFormatService.decimalSeparator);
+
+    if (this.decimalPlaces() === 0) {
+      return false;
+    }
+
+    return (
+      indexDecimalSep === -1 ||
+      (this.decimalPlaces() > 0 && selectionStart !== selectionEnd && indexDecimalSep >= selectionStart && indexDecimalSep <= selectionEnd)
+    );
+  }
+
+  private isValidDecimalPlace(event: KeyboardEvent, element: HTMLInputElement, value: string): boolean {
+    if (!NumberFormatService.NUMBERS.includes(event.key)) {
+      return true;
+    }
+
+    const selectionStart = element.selectionStart ?? 0;
+    const selectionEnd = element.selectionEnd ?? selectionStart;
+    const indexDecimalSep = value.indexOf(this.numberFormatService.decimalSeparator);
+
+    return (
+      indexDecimalSep === -1 ||
+      indexDecimalSep >= selectionStart ||
+      selectionStart !== selectionEnd ||
+      value.length <= indexDecimalSep + this.decimalPlaces()
+    );
+  }
+
+  private getEventInput(event: Event): HTMLInputElement {
+    return event.target instanceof HTMLInputElement ? event.target : this.inputElement;
+  }
+
+  private preventDefault(event: Event): false {
+    event.preventDefault();
+    return false;
+  }
+
+  private parseNumericValue(value: string): number {
+    return Number.parseFloat(
+      this.numberFormatService
+        .strip(value, { decimalPlaces: this.decimalPlaces() })
+        .replace(this.numberFormatService.decimalSeparator, '.'),
+    );
+  }
+
+  private getComparableOriginalValue(): number {
+    return typeof this.originalValue === 'number' ? this.roundOrTruncate(this.originalValue) : NaN;
+  }
+
+  private syncUnitSymbol(): void {
+    if (!this.viewInitialized) {
+      return;
+    }
+
+    if (!this.unit()) {
+      this.removeUnitSpan();
+      return;
+    }
+
+    if (!this.unitSpan || this.unitSpanPosition !== this.unitPosition()) {
+      this.createUnitSpan();
+    }
+
+    if (!this.unitSpan) {
+      return;
+    }
+
+    this.unitSpan.textContent = this.unit();
+
+    if (this.textAlign() === 'left' && this.unitPosition() === 'right') {
+      this.unitSpan.style.display = NumberFormatService.valueIsSet(this.displayValue) ? 'unset' : 'none';
+    } else {
+      this.unitSpan.style.display = '';
+      this.unitSpan.style.left = '';
+      this.unitSpan.style.position = '';
     }
   }
 
-  private detachListener(): void {
-    if (this.inputChangeListener) {
-      this.inputChangeListener();
-      delete this.inputChangeListener;
+  private createUnitSpan(): void {
+    const unitContainer = this.getUnitContainer();
+
+    if (!unitContainer) {
+      return;
     }
-    if (this.keydownListener) {
-      this.keydownListener();
-      delete this.keydownListener;
+
+    this.removeUnitSpan();
+    this.unitSpan = this.renderer.createElement('span') as HTMLSpanElement;
+    this.unitSpanPosition = this.unitPosition();
+    this.renderer.addClass(this.unitSpan, 'mad-numeric-field-unit');
+
+    if (this.unitPosition() === 'left') {
+      this.renderer.setAttribute(this.unitSpan, 'matPrefix', '');
+      this.renderer.setAttribute(this.unitSpan, 'matTextPrefix', '');
+      this.renderer.setStyle(this.unitSpan, 'padding-right', '5px');
+      this.renderer.insertBefore(unitContainer, this.unitSpan, this.getUnitInsertReference(unitContainer));
+    } else {
+      this.renderer.setAttribute(this.unitSpan, 'matSuffix', '');
+      this.renderer.setAttribute(this.unitSpan, 'matTextSuffix', '');
+      this.renderer.setStyle(this.unitSpan, 'padding-left', '5px');
+      this.renderer.appendChild(unitContainer, this.unitSpan);
     }
-    if (this.keyupListener) {
-      this.keyupListener();
-      delete this.keyupListener;
+  }
+
+  private getUnitContainer(): HTMLElement | null {
+    const materialFormFieldFlex = this.inputElement.closest('.mat-mdc-form-field-flex');
+
+    if (materialFormFieldFlex instanceof HTMLElement) {
+      return materialFormFieldFlex;
     }
+
+    return this.inputElement.parentElement;
+  }
+
+  private getUnitInsertReference(unitContainer: HTMLElement): HTMLElement | null {
+    if (this.inputElement.parentElement?.parentElement === unitContainer) {
+      return this.inputElement.parentElement;
+    }
+
+    if (this.inputElement.parentElement === unitContainer) {
+      return this.inputElement;
+    }
+
+    return null;
+  }
+
+  private updateTrailingUnitPosition(textFormatted: string): void {
+    if (this.textAlign() !== 'left' || this.unitPosition() !== 'right' || !this.unitSpan || !this.inputElement.parentElement) {
+      return;
+    }
+
+    const inputStyles = window.getComputedStyle(this.inputElement.parentElement);
+    this.unitSpan.style.position = 'absolute';
+    this.unitSpan.style.marginTop = inputStyles.getPropertyValue('border-top-width');
+    this.unitSpan.style.paddingTop = inputStyles.getPropertyValue('padding-top');
+    this.unitSpan.style.paddingBottom = inputStyles.getPropertyValue('padding-bottom');
+
+    this.ensureTextSpan(inputStyles);
+
+    if (!this.textSpan) {
+      return;
+    }
+
+    this.textSpan.textContent = textFormatted;
+
+    const width = Math.min(this.inputElement.clientWidth - this.unitSpan.clientWidth, Math.ceil(this.textSpan.clientWidth));
+    this.unitSpan.style.left = `${Math.max(width, 0)}px`;
+  }
+
+  private ensureTextSpan(inputStyles: CSSStyleDeclaration): void {
+    if (this.textSpan) {
+      return;
+    }
+
+    this.textSpan = document.createElement('span');
+    document.body.appendChild(this.textSpan);
+    this.textSpan.style.font = inputStyles.getPropertyValue('font');
+    this.textSpan.style.fontSize = inputStyles.getPropertyValue('font-size');
+    this.textSpan.style.height = 'auto';
+    this.textSpan.style.width = 'auto';
+    this.textSpan.style.position = 'absolute';
+    this.textSpan.style.top = '0';
+    this.textSpan.style.whiteSpace = 'nowrap';
+    this.textSpan.style.visibility = 'hidden';
+  }
+
+  private removeUnitSpan(): void {
+    if (!this.unitSpan) {
+      return;
+    }
+
+    this.unitSpan.remove();
+    this.unitSpan = undefined;
+    this.unitSpanPosition = undefined;
+  }
+
+  private removeTextSpan(): void {
+    if (!this.textSpan) {
+      return;
+    }
+
+    this.textSpan.remove();
+    this.textSpan = undefined;
+  }
+
+  private setCursorPosition(element: HTMLInputElement, position: number): void {
+    element.setSelectionRange(position, position);
+  }
+
+  private isEmptyNumericValue(value: NumericValue): boolean {
+    return value === undefined || (typeof value === 'number' && Number.isNaN(value));
   }
 
   private roundOrTruncate(value: number): number {
-    if (this.roundValue) {
-      return Math.round(value * Math.pow(10, this.decimalPlaces)) / Math.pow(10, this.decimalPlaces);
+    if (this.roundValue()) {
+      return Math.round(value * Math.pow(10, this.decimalPlaces())) / Math.pow(10, this.decimalPlaces());
     }
 
     const method = value < 0 ? 'ceil' : 'floor';
-    return Math[method](+(value * Math.pow(10, this.decimalPlaces)).toFixed(this.decimalPlaces)) / Math.pow(10, this.decimalPlaces);
+    return Math[method](+(value * Math.pow(10, this.decimalPlaces())).toFixed(this.decimalPlaces())) / Math.pow(10, this.decimalPlaces());
   }
 }

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
@@ -12,6 +12,7 @@ import {
   effect,
   forwardRef,
   inject,
+  Injector,
   input,
   numberAttribute,
   OnDestroy,
@@ -19,6 +20,7 @@ import {
   Renderer2,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { MatInput } from '@angular/material/input';
 import { NumberFormatService } from './number-format.service';
 
 const CONTROL_KEYS = new Set([
@@ -78,11 +80,13 @@ export class NumericFieldDirective implements AfterViewInit, OnDestroy, ControlV
 
   private readonly renderer = inject(Renderer2);
   private readonly inputEl = inject<ElementRef<HTMLInputElement>>(ElementRef);
+  private readonly injector = inject(Injector);
   private readonly numberFormatService = inject(NumberFormatService);
 
   private displayValue = '';
   private originalValue: NumericValue = NaN;
   private numericValueInternal: NumericValue;
+  private matInput: MatInput | null = null;
   private textSpan?: HTMLSpanElement;
   private unitSpan?: HTMLSpanElement;
   private unitSpanPosition?: UnitPosition;
@@ -138,7 +142,9 @@ export class NumericFieldDirective implements AfterViewInit, OnDestroy, ControlV
 
   ngAfterViewInit(): void {
     this.viewInitialized = true;
+    this.matInput = this.injector.get(MatInput, null, { self: true, optional: true });
     this.syncUnitSymbol();
+    this.notifyMatInputStateChanged();
   }
 
   ngOnDestroy(): void {
@@ -218,6 +224,7 @@ export class NumericFieldDirective implements AfterViewInit, OnDestroy, ControlV
   updateInput(value: string): void {
     this.displayValue = value;
     this.inputElement.value = value;
+    this.notifyMatInputStateChanged();
     this.numericValueInternal = this.parseNumericValue(value);
 
     if (this.numericValueInternal !== this.getComparableOriginalValue()) {
@@ -348,6 +355,10 @@ export class NumericFieldDirective implements AfterViewInit, OnDestroy, ControlV
   private preventDefault(event: Event): false {
     event.preventDefault();
     return false;
+  }
+
+  private notifyMatInputStateChanged(): void {
+    this.matInput?.stateChanges.next();
   }
 
   private parseNumericValue(value: string): number {

--- a/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
+++ b/projects/material-addons/src/lib/numeric-field/numeric-field.directive.ts
@@ -63,17 +63,15 @@ type NumericValueInput = NumericValue | typeof UNSET_NUMERIC_VALUE;
   standalone: true,
 })
 export class NumericFieldDirective implements AfterViewInit, OnDestroy, ControlValueAccessor {
-  readonly textAlign = input<UnitPosition>('right', { alias: 'textAlign' });
+  readonly textAlign = input<UnitPosition>('right');
   readonly decimalPlaces = input(NumberFormatService.DEFAULT_DECIMAL_PLACES, {
-    alias: 'decimalPlaces',
     transform: (value: unknown) => numberAttribute(value, NumberFormatService.DEFAULT_DECIMAL_PLACES),
   });
   readonly roundValue = input(false, { alias: 'roundDisplayValue', transform: booleanAttribute });
-  readonly autofillDecimals = input(false, { alias: 'autofillDecimals', transform: booleanAttribute });
-  readonly unit = input<string | null>(null, { alias: 'unit' });
-  readonly unitPosition = input<UnitPosition>('right', { alias: 'unitPosition' });
+  readonly autofillDecimals = input(false, { transform: booleanAttribute });
+  readonly unit = input<string | null>(null);
+  readonly unitPosition = input<UnitPosition>('right');
   readonly numericValue = input<NumericValueInput, NumericValue>(UNSET_NUMERIC_VALUE, {
-    alias: 'numericValue',
     transform: (value) => value,
   });
   readonly numericValueChanged = output<number>({ alias: 'numericValueChange' });

--- a/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.html
+++ b/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.html
@@ -1,0 +1,137 @@
+<div class="api-specification">
+  <h2>Properties</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Default Value</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>madNumericField</code></td>
+        <td><code>Directive</code></td>
+        <td>-</td>
+        <td>Applies numeric formatting and Angular forms integration to an input element.</td>
+      </tr>
+      <tr>
+        <td><code>textAlign</code></td>
+        <td><code>'right' | 'left'</code></td>
+        <td><code>'right'</code></td>
+        <td>Controls the input text alignment. Right alignment is the default for numeric values.</td>
+      </tr>
+      <tr>
+        <td><code>decimalPlaces</code></td>
+        <td><code>number</code></td>
+        <td><code>2</code></td>
+        <td>Maximum amount of decimal places accepted and displayed.</td>
+      </tr>
+      <tr>
+        <td><code>roundDisplayValue</code></td>
+        <td><code>boolean</code></td>
+        <td><code>false</code></td>
+        <td>Rounds the displayed value when enabled. Values are truncated by default.</td>
+      </tr>
+      <tr>
+        <td><code>autofillDecimals</code></td>
+        <td><code>boolean</code></td>
+        <td><code>false</code></td>
+        <td>Fills missing decimal places during final formatting, for example on blur.</td>
+      </tr>
+      <tr>
+        <td><code>unit</code></td>
+        <td><code>string | null</code></td>
+        <td><code>null</code></td>
+        <td>Optional unit text rendered next to the formatted input value.</td>
+      </tr>
+      <tr>
+        <td><code>unitPosition</code></td>
+        <td><code>'right' | 'left'</code></td>
+        <td><code>'right'</code></td>
+        <td>Controls whether the unit is rendered before or after the input value.</td>
+      </tr>
+      <tr>
+        <td><code>numericValue</code></td>
+        <td><code>number | null | undefined</code></td>
+        <td><code>undefined</code></td>
+        <td>Optional numeric value input for two-way binding through <code>numericValueChange</code>.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Events</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Event</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>numericValueChange</code></td>
+        <td><code>number</code></td>
+        <td>Emits the parsed numeric value when the displayed input value changes.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Forms Behavior</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Feature</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>ngModel</code></td>
+        <td>Supported through <code>ControlValueAccessor</code>.</td>
+      </tr>
+      <tr>
+        <td><code>formControlName</code></td>
+        <td>Supported through <code>ControlValueAccessor</code>.</td>
+      </tr>
+      <tr>
+        <td>Empty value</td>
+        <td>Returns <code>undefined</code> to Angular forms so required validators work with empty input.</td>
+      </tr>
+      <tr>
+        <td>Disabled state</td>
+        <td>Updates the native input disabled property through the value accessor.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Locale Behavior</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Locale</th>
+        <th>Decimal Separator</th>
+        <th>Grouping Separator</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>de-DE</code></td>
+        <td><code>,</code></td>
+        <td><code>.</code></td>
+      </tr>
+      <tr>
+        <td><code>de-AT</code></td>
+        <td><code>,</code></td>
+        <td><code>.</code></td>
+      </tr>
+      <tr>
+        <td><code>en-EN</code></td>
+        <td><code>.</code></td>
+        <td><code>,</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.html
+++ b/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.html
@@ -111,7 +111,7 @@
   <table>
     <thead>
       <tr>
-        <th>Locale</th>
+        <th>Locale Source</th>
         <th>Decimal Separator</th>
         <th>Grouping Separator</th>
       </tr>
@@ -125,10 +125,20 @@
       <tr>
         <td><code>de-AT</code></td>
         <td><code>,</code></td>
-        <td><code>.</code></td>
+        <td>Resolved from the <code>group</code> format part</td>
       </tr>
       <tr>
         <td><code>en-EN</code></td>
+        <td><code>.</code></td>
+        <td><code>,</code></td>
+      </tr>
+      <tr>
+        <td>Other supported <code>Intl.NumberFormat</code> locales</td>
+        <td>Resolved from the <code>decimal</code> format part</td>
+        <td>Resolved from the <code>group</code> format part</td>
+      </tr>
+      <tr>
+        <td>Unsupported or invalid locale</td>
         <td><code>.</code></td>
         <td><code>,</code></td>
       </tr>

--- a/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.scss
+++ b/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.scss
@@ -1,0 +1,24 @@
+.api-specification {
+  font-family: sans-serif;
+}
+
+.api-specification h2 {
+  color: #333;
+}
+
+.api-specification table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+.api-specification th,
+.api-specification td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+.api-specification th {
+  background-color: #f2f2f2;
+}

--- a/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.ts
+++ b/src/app/component-demos/numeric-field-demo/numeric-field-demo-api-spec/numeric-field-demo-api-spec.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-numeric-field-demo-api-spec',
+  imports: [],
+  templateUrl: './numeric-field-demo-api-spec.component.html',
+  styleUrl: './numeric-field-demo-api-spec.component.scss',
+})
+export class NumericFieldDemoApiSpecComponent {}

--- a/src/app/component-demos/numeric-field-demo/numeric-field-demo.component.html
+++ b/src/app/component-demos/numeric-field-demo/numeric-field-demo.component.html
@@ -1,18 +1,29 @@
-<p>The Numeric Field is used to enter numeric values of a certain type.</p>
-<h2>Usage</h2>
+<p>Use to enter and display numeric values with locale-aware separators, decimal-place limits, optional rounding, and optional units.</p>
+
+<h2>Use When</h2>
 <ul>
-  <li>Invalid characters are ignored during input.</li>
-  <li>Amount of decimal places should be defined according to the input type and usecase.</li>
-  <li>Decimal separator and grouping separator should be set according to locale.</li>
+  <li>Users need to enter amounts, percentages, dimensions, mileage, power, weight, or other numeric values</li>
+  <li>The input should reject non-numeric characters while preserving normal form behavior</li>
+  <li>The displayed value should use grouping separators and a fixed decimal precision</li>
+  <li>A unit should be displayed with the value without changing the bound numeric value</li>
 </ul>
+
+<h2>Behavior</h2>
+<ul>
+  <li>Supports <code>ngModel</code>, <code>formControl</code>, and <code>formControlName</code> through Angular forms</li>
+  <li>Invalid characters are prevented during keyboard input and stripped from pasted values</li>
+  <li>Decimal places are truncated by default and rounded when <code>roundDisplayValue</code> is enabled</li>
+  <li>Missing decimal places are filled on final formatting when <code>autofillDecimals</code> is enabled</li>
+  <li>Supported locales are <code>de-DE</code>, <code>de-AT</code>, and <code>en-EN</code></li>
+</ul>
+
 <p>Because the numeric field is a directive, it can be applied on any input element.</p>
 <p>
-  Import the <app-text-code>NumericFieldModule.forRoot()</app-text-code> in your app.module.ts and use it via the directive
-  <app-text-code>madNumericField</app-text-code>.
+  Import the <app-text-code>NumericFieldModule</app-text-code> and use it via the directive <app-text-code>madNumericField</app-text-code>.
 </p>
 
-<h2>Use when</h2>
-<ul>
-  <li>One of the following inputs is required from the user:</li>
-</ul>
+<p>Basic usage with optional values</p>
 <example-viewer [example]="numericFieldWrapperComponent"></example-viewer>
+
+<h2>API Specification</h2>
+<app-numeric-field-demo-api-spec></app-numeric-field-demo-api-spec>

--- a/src/app/component-demos/numeric-field-demo/numeric-field-demo.component.html
+++ b/src/app/component-demos/numeric-field-demo/numeric-field-demo.component.html
@@ -14,7 +14,7 @@
   <li>Invalid characters are prevented during keyboard input and stripped from pasted values</li>
   <li>Decimal places are truncated by default and rounded when <code>roundDisplayValue</code> is enabled</li>
   <li>Missing decimal places are filled on final formatting when <code>autofillDecimals</code> is enabled</li>
-  <li>Supported locales are <code>de-DE</code>, <code>de-AT</code>, and <code>en-EN</code></li>
+  <li>Separators follow the Angular <code>LOCALE_ID</code> through <code>Intl.NumberFormat</code>, with English fallback separators</li>
 </ul>
 
 <p>Because the numeric field is a directive, it can be applied on any input element.</p>

--- a/src/app/component-demos/numeric-field-demo/numeric-field-demo.component.ts
+++ b/src/app/component-demos/numeric-field-demo/numeric-field-demo.component.ts
@@ -3,12 +3,13 @@ import { Example } from '../../components/example-viewer/example.class';
 import { NumericFieldWrapperComponent } from '../../example-components/numeric-field-wrapper/numeric-field-wrapper.component';
 import { ExampleViewerComponent } from '../../components/example-viewer/example-viewer.component';
 import { TextCodeComponent } from '../../components/text-code/text-code.component';
+import { NumericFieldDemoApiSpecComponent } from './numeric-field-demo-api-spec/numeric-field-demo-api-spec.component';
 
 @Component({
   selector: 'app-numeric-field-demo',
   templateUrl: './numeric-field-demo.component.html',
   styleUrls: ['./numeric-field-demo.component.scss'],
-  imports: [TextCodeComponent, ExampleViewerComponent],
+  imports: [TextCodeComponent, ExampleViewerComponent, NumericFieldDemoApiSpecComponent],
 })
 export class NumericFieldDemoComponent {
   numericFieldWrapperComponent = new Example(NumericFieldWrapperComponent, 'numeric-field-wrapper', 'Numeric form field wrapper');

--- a/src/app/example-components/numeric-field-wrapper/numeric-field-wrapper.component.html
+++ b/src/app/example-components/numeric-field-wrapper/numeric-field-wrapper.component.html
@@ -1,183 +1,166 @@
-<div class="input-wrapper">
-  <mat-checkbox [checked]="textIsEditable" (change)="textIsEditable = !textIsEditable"> Text editable </mat-checkbox>
+<div class="example-toolbar">
+  <mat-checkbox [checked]="textIsEditable" (change)="textIsEditable = $event.checked">Editable</mat-checkbox>
+  <mat-checkbox [checked]="disabled" (change)="setDisabledState($event.checked)">Disabled</mat-checkbox>
 </div>
 
-<div [formGroup]="form" class="input-wrapper">
+<div [formGroup]="form" class="numeric-field-grid">
   <mad-readonly-form-field-wrapper
     [readonly]="!textIsEditable"
-    [value]="form.get('moneyAmount').value"
-    textAlign="left"
-    unit="€"
-    unitPosition="right"
-    [autofillDecimals]="true"
+    [value]="form.controls.defaultValue.value"
+    [formatNumber]="true"
+    textAlign="right"
   >
-    <mat-form-field class="form-group">
-      <mat-label>Money Amount</mat-label>
+    <mat-form-field>
+      <mat-label>Default numeric input</mat-label>
+      <input formControlName="defaultValue" autocomplete="off" matInput madNumericField />
+    </mat-form-field>
+  </mad-readonly-form-field-wrapper>
+
+  <mad-readonly-form-field-wrapper
+    [readonly]="!textIsEditable"
+    [value]="form.controls.moneyAmount.value"
+    [formatNumber]="true"
+    [autofillDecimals]="true"
+    textAlign="right"
+    unit="EUR"
+    unitPosition="right"
+    [errorMessage]="form.controls.moneyAmount.invalid ? 'Please enter a value greater than or equal to 0' : null"
+  >
+    <mat-form-field>
+      <mat-label>Money with autofill decimals</mat-label>
       <input
         formControlName="moneyAmount"
         autocomplete="off"
-        class="form-control"
-        id="moneyAmount"
         matInput
-        unit="€"
+        unit="EUR"
+        unitPosition="right"
         [autofillDecimals]="true"
-        textAlign="right"
         madNumericField
       />
-      @if (!form.get('moneyAmount').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
+      @if (form.controls.moneyAmount.invalid) {
+        <mat-error>Please enter a value greater than or equal to 0</mat-error>
       }
     </mat-form-field>
   </mad-readonly-form-field-wrapper>
 
   <mad-readonly-form-field-wrapper
     [readonly]="!textIsEditable"
-    [value]="form.get('weight').value"
-    textAlign="right"
-    unit="kg"
-    unitPosition="right"
-  >
-    <mat-form-field class="form-group">
-      <mat-label>Weight</mat-label>
-      <input formControlName="weight" autocomplete="off" class="form-control" id="weight" matInput unit="kg" madNumericField />
-      @if (!form.get('weight').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
-      }
-    </mat-form-field>
-  </mad-readonly-form-field-wrapper>
-
-  <mad-readonly-form-field-wrapper
-    [readonly]="!textIsEditable"
-    [value]="form.get('emission').value"
-    textAlign="right"
-    unit="g/km"
-    unitPosition="right"
-  >
-    <mat-form-field class="form-group">
-      <mat-label>Emission</mat-label>
-      <input formControlName="emission" autocomplete="off" class="form-control" id="emission" matInput unit="g/km" madNumericField />
-      @if (!form.get('emission').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
-      }
-    </mat-form-field>
-  </mad-readonly-form-field-wrapper>
-
-  <mad-readonly-form-field-wrapper
-    [readonly]="!textIsEditable"
-    [value]="form.get('kilometer').value"
+    [value]="form.controls.integerValue.value"
+    [formatNumber]="true"
+    [decimalPlaces]="0"
     textAlign="right"
     unit="km"
     unitPosition="right"
+    [errorMessage]="form.controls.integerValue.invalid ? 'Please enter a whole number greater than or equal to 0' : null"
   >
-    <mat-form-field class="form-group">
-      <mat-label>Kilometer Reading</mat-label>
-      <input formControlName="kilometer" autocomplete="off" class="form-control" id="kilometer" matInput unit="km" madNumericField />
-      @if (!form.get('kilometer').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
+    <mat-form-field>
+      <mat-label>Integer value</mat-label>
+      <input formControlName="integerValue" autocomplete="off" matInput unit="km" [decimalPlaces]="0" madNumericField />
+      @if (form.controls.integerValue.invalid) {
+        <mat-error>Please enter a whole number greater than or equal to 0</mat-error>
       }
     </mat-form-field>
   </mad-readonly-form-field-wrapper>
 
   <mad-readonly-form-field-wrapper
     [readonly]="!textIsEditable"
-    [value]="form.get('cubicCapacity').value"
-    textAlign="right"
-    unit="cc"
-    unitPosition="right"
-  >
-    <mat-form-field class="form-group">
-      <mat-label>Cubic Capacity</mat-label>
-      <input
-        formControlName="cubicCapacity"
-        autocomplete="off"
-        class="form-control"
-        id="cubicCapacity"
-        matInput
-        unit="cc"
-        madNumericField
-      />
-      @if (!form.get('cubicCapacity').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
-      }
-    </mat-form-field>
-  </mad-readonly-form-field-wrapper>
-
-  <mad-readonly-form-field-wrapper
-    [readonly]="!textIsEditable"
-    [value]="form.get('millimeter').value"
+    [value]="form.controls.precisionValue.value"
+    [formatNumber]="true"
+    [decimalPlaces]="4"
     textAlign="right"
     unit="mm"
     unitPosition="right"
+    [errorMessage]="form.controls.precisionValue.invalid ? 'Please enter a value greater than or equal to 0' : null"
   >
-    <mat-form-field class="form-group">
-      <mat-label>Millimeter</mat-label>
-      <input formControlName="millimeter" autocomplete="off" class="form-control" id="millimeter" matInput unit="mm" madNumericField />
-      @if (!form.get('millimeter').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
+    <mat-form-field>
+      <mat-label>Precision value</mat-label>
+      <input formControlName="precisionValue" autocomplete="off" matInput unit="mm" [decimalPlaces]="4" madNumericField />
+      @if (form.controls.precisionValue.invalid) {
+        <mat-error>Please enter a value greater than or equal to 0</mat-error>
       }
     </mat-form-field>
   </mad-readonly-form-field-wrapper>
 
   <mad-readonly-form-field-wrapper
     [readonly]="!textIsEditable"
-    [value]="form.get('kilowatt').value"
+    [value]="form.controls.rightUnitValue.value"
+    [formatNumber]="true"
+    textAlign="right"
+    unit="kg"
+    unitPosition="right"
+    [errorMessage]="form.controls.rightUnitValue.invalid ? 'Please enter a value greater than or equal to 0' : null"
+  >
+    <mat-form-field>
+      <mat-label>Right-positioned unit</mat-label>
+      <input formControlName="rightUnitValue" autocomplete="off" matInput unit="kg" unitPosition="right" madNumericField />
+      @if (form.controls.rightUnitValue.invalid) {
+        <mat-error>Please enter a value greater than or equal to 0</mat-error>
+      }
+    </mat-form-field>
+  </mad-readonly-form-field-wrapper>
+
+  <mad-readonly-form-field-wrapper
+    [readonly]="!textIsEditable"
+    [value]="form.controls.leftUnitValue.value"
+    [formatNumber]="true"
+    [autofillDecimals]="true"
+    textAlign="left"
+    unit="EUR"
+    unitPosition="left"
+    [errorMessage]="form.controls.leftUnitValue.invalid ? 'Please enter a value greater than or equal to 0' : null"
+  >
+    <mat-form-field>
+      <mat-label>Left-positioned unit</mat-label>
+      <input
+        formControlName="leftUnitValue"
+        autocomplete="off"
+        matInput
+        unit="EUR"
+        unitPosition="left"
+        textAlign="left"
+        [autofillDecimals]="true"
+        madNumericField
+      />
+      @if (form.controls.leftUnitValue.invalid) {
+        <mat-error>Please enter a value greater than or equal to 0</mat-error>
+      }
+    </mat-form-field>
+  </mad-readonly-form-field-wrapper>
+
+  <mad-readonly-form-field-wrapper
+    [readonly]="!textIsEditable"
+    [value]="form.controls.roundedValue.value"
+    [formatNumber]="true"
+    [roundDisplayValue]="true"
     textAlign="right"
     unit="kW"
     unitPosition="right"
+    [errorMessage]="form.controls.roundedValue.invalid ? 'Please enter a value greater than or equal to 0' : null"
   >
-    <mat-form-field class="form-group">
-      <mat-label>Kilowatt</mat-label>
-      <input formControlName="kilowatt" autocomplete="off" class="form-control" id="kilowatt" matInput unit="kW" madNumericField />
-      @if (!form.get('kilowatt').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
+    <mat-form-field>
+      <mat-label>Rounded display value</mat-label>
+      <input formControlName="roundedValue" autocomplete="off" matInput unit="kW" [roundDisplayValue]="true" madNumericField />
+      @if (form.controls.roundedValue.invalid) {
+        <mat-error>Please enter a value greater than or equal to 0</mat-error>
       }
     </mat-form-field>
   </mad-readonly-form-field-wrapper>
 
   <mad-readonly-form-field-wrapper
     [readonly]="!textIsEditable"
-    [value]="form.get('timeunit').value"
-    textAlign="right"
-    unit="TU"
-    unitPosition="right"
-  >
-    <mat-form-field class="form-group">
-      <mat-label>Timeunit</mat-label>
-      <input formControlName="timeunit" autocomplete="off" class="form-control" id="timeunit" matInput unit="TU" madNumericField />
-      @if (!form.get('timeunit').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
-      }
-    </mat-form-field>
-  </mad-readonly-form-field-wrapper>
-
-  <mad-readonly-form-field-wrapper
-    [readonly]="!textIsEditable"
-    [value]="form.get('horsepower').value"
-    textAlign="right"
-    unit="hp"
-    unitPosition="right"
-  >
-    <mat-form-field class="form-group">
-      <mat-label>Horsepower</mat-label>
-      <input formControlName="horsepower" autocomplete="off" class="form-control" id="horsepower" matInput unit="hp" madNumericField />
-      @if (!form.get('horsepower').valid) {
-        <mat-error> Please enter a value greater than or equal to 0 </mat-error>
-      }
-    </mat-form-field>
-  </mad-readonly-form-field-wrapper>
-
-  <mad-readonly-form-field-wrapper
-    [readonly]="!textIsEditable"
-    [value]="form.get('percentage').value"
+    [value]="form.controls.percentage.value"
+    [formatNumber]="true"
+    [decimalPlaces]="0"
     textAlign="right"
     unit="%"
     unitPosition="right"
+    [errorMessage]="form.controls.percentage.invalid ? 'Please enter a value between 0 and 100' : null"
   >
-    <mat-form-field class="form-group">
-      <mat-label>Percentage</mat-label>
-      <input formControlName="percentage" autocomplete="off" class="form-control" id="percentage" matInput unit="%" madNumericField />
-      @if (!form.get('percentage').valid) {
-        <mat-error> Please enter a value between 0 and 100 </mat-error>
+    <mat-form-field>
+      <mat-label>Percentage with validation</mat-label>
+      <input formControlName="percentage" autocomplete="off" matInput unit="%" [decimalPlaces]="0" madNumericField />
+      @if (form.controls.percentage.invalid) {
+        <mat-error>Please enter a value between 0 and 100</mat-error>
       }
     </mat-form-field>
   </mad-readonly-form-field-wrapper>

--- a/src/app/example-components/numeric-field-wrapper/numeric-field-wrapper.component.scss
+++ b/src/app/example-components/numeric-field-wrapper/numeric-field-wrapper.component.scss
@@ -1,6 +1,19 @@
-.input-wrapper {
-  width: 15em;
-  margin-top: 2em;
+.example-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.numeric-field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px 24px;
+  max-width: 960px;
+}
+
+mat-form-field {
+  width: 100%;
 }
 
 .text-right {

--- a/src/app/example-components/numeric-field-wrapper/numeric-field-wrapper.component.ts
+++ b/src/app/example-components/numeric-field-wrapper/numeric-field-wrapper.component.ts
@@ -1,72 +1,75 @@
-import { Component, OnInit } from '@angular/core';
-import { UntypedFormGroup, UntypedFormControl, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Component } from '@angular/core';
+import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
 
-import { MatInputModule } from '@angular/material/input';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { ReadOnlyFormFieldModule, NumericFieldModule } from '@porscheinformatik/material-addons';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { NumericFieldModule, ReadOnlyFormFieldModule } from '@porscheinformatik/material-addons';
+
+type NumericValueControl = FormControl<number | null | undefined>;
+
+const REQUIRED_VALIDATOR = (control: AbstractControl): ValidationErrors | null => Validators.required(control);
+
+interface NumericFieldDemoForm {
+  defaultValue: NumericValueControl;
+  moneyAmount: NumericValueControl;
+  integerValue: NumericValueControl;
+  precisionValue: NumericValueControl;
+  rightUnitValue: NumericValueControl;
+  leftUnitValue: NumericValueControl;
+  roundedValue: NumericValueControl;
+  percentage: NumericValueControl;
+}
 
 @Component({
   selector: 'app-numeric-field-wrapper',
   templateUrl: './numeric-field-wrapper.component.html',
   styleUrls: ['./numeric-field-wrapper.component.scss'],
-  imports: [
-    MatCheckboxModule,
-    FormsModule,
-    ReactiveFormsModule,
-    ReadOnlyFormFieldModule,
-    MatFormFieldModule,
-    MatInputModule,
-    NumericFieldModule,
-  ],
+  imports: [MatCheckboxModule, ReactiveFormsModule, ReadOnlyFormFieldModule, MatFormFieldModule, MatInputModule, NumericFieldModule],
 })
-export class NumericFieldWrapperComponent implements OnInit {
-  form: UntypedFormGroup;
+export class NumericFieldWrapperComponent {
   textIsEditable = true;
+  disabled = false;
 
-  ngOnInit(): void {
-    this.form = new UntypedFormGroup({
-      // eslint-disable-next-line
-      moneyAmount: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      weight: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      emission: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      kilometer: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      cubicCapacity: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      millimeter: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      kilowatt: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      timeunit: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      horsepower: new UntypedFormControl(undefined, {
-        validators: [Validators.required, Validators.min(0)],
-        updateOn: 'blur',
-      }),
-      percentage: new UntypedFormControl(undefined, {
-        validators: [Validators.min(0), Validators.max(100)],
-        updateOn: 'blur',
-      }),
-    });
+  readonly form = new FormGroup<NumericFieldDemoForm>({
+    defaultValue: new FormControl<number | null | undefined>(1234.56),
+    moneyAmount: new FormControl<number | null | undefined>(1234.5, {
+      validators: [REQUIRED_VALIDATOR, Validators.min(0)],
+      updateOn: 'blur',
+    }),
+    integerValue: new FormControl<number | null | undefined>(50000, {
+      validators: [REQUIRED_VALIDATOR, Validators.min(0)],
+      updateOn: 'blur',
+    }),
+    precisionValue: new FormControl<number | null | undefined>(12.3456, {
+      validators: [REQUIRED_VALIDATOR, Validators.min(0)],
+      updateOn: 'blur',
+    }),
+    rightUnitValue: new FormControl<number | null | undefined>(1540, {
+      validators: [REQUIRED_VALIDATOR, Validators.min(0)],
+      updateOn: 'blur',
+    }),
+    leftUnitValue: new FormControl<number | null | undefined>(99.99, {
+      validators: [REQUIRED_VALIDATOR, Validators.min(0)],
+      updateOn: 'blur',
+    }),
+    roundedValue: new FormControl<number | null | undefined>(1234.567, {
+      validators: [REQUIRED_VALIDATOR, Validators.min(0)],
+      updateOn: 'blur',
+    }),
+    percentage: new FormControl<number | null | undefined>(25, {
+      validators: [REQUIRED_VALIDATOR, Validators.min(0), Validators.max(100)],
+      updateOn: 'blur',
+    }),
+  });
+
+  setDisabledState(disabled: boolean): void {
+    this.disabled = disabled;
+
+    if (disabled) {
+      this.form.disable({ emitEvent: false });
+    } else {
+      this.form.enable({ emitEvent: false });
+    }
   }
 }

--- a/src/stories/numeric-field.stories.ts
+++ b/src/stories/numeric-field.stories.ts
@@ -1,0 +1,301 @@
+import { JsonPipe } from '@angular/common';
+import { Component, computed, effect, input, numberAttribute, signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { NumberFormatService, NumericFieldDirective } from '@porscheinformatik/material-addons';
+
+type UnitPosition = 'right' | 'left';
+
+interface NumericFieldStoryArgs {
+  label: string;
+  value: number | null | undefined;
+  decimalPlaces: number;
+  roundDisplayValue: boolean;
+  autofillDecimals: boolean;
+  unit: string | null;
+  unitPosition: UnitPosition;
+  textAlign: UnitPosition;
+  disabled: boolean;
+}
+
+@Component({
+  selector: 'app-numeric-field-directive-story',
+  imports: [JsonPipe, MatFormFieldModule, MatInputModule, NumericFieldDirective, ReactiveFormsModule],
+  template: `
+    <div style="display: grid; gap: 1rem; max-width: 420px;">
+      <mat-form-field appearance="outline">
+        <mat-label>{{ label() }}</mat-label>
+        <input
+          matInput
+          autocomplete="off"
+          [formControl]="control"
+          [decimalPlaces]="decimalPlaces()"
+          [roundDisplayValue]="roundDisplayValue()"
+          [autofillDecimals]="autofillDecimals()"
+          [unit]="unit()"
+          [unitPosition]="unitPosition()"
+          [textAlign]="textAlign()"
+          madNumericField
+        />
+      </mat-form-field>
+
+      <div style="display: grid; gap: 0.25rem; font-size: 0.875rem;">
+        <div><strong>Form value:</strong> {{ control.value | json }}</div>
+        <div><strong>Disabled:</strong> {{ control.disabled }}</div>
+      </div>
+    </div>
+  `,
+})
+class NumericFieldDirectiveStoryComponent {
+  readonly label = input('Amount');
+  readonly value = input<number | null | undefined>(1234.56);
+  readonly decimalPlaces = input(2, { transform: numberAttribute });
+  readonly roundDisplayValue = input(false);
+  readonly autofillDecimals = input(false);
+  readonly unit = input<string | null>('EUR');
+  readonly unitPosition = input<UnitPosition>('right');
+  readonly textAlign = input<UnitPosition>('right');
+  readonly disabled = input(false);
+
+  readonly control = new FormControl<number | null | undefined>(1234.56);
+
+  private readonly valueEffect = effect(() => {
+    const value = this.value();
+
+    if (this.control.value !== value) {
+      this.control.setValue(value, { emitEvent: false });
+    }
+  });
+
+  private readonly disabledEffect = effect(() => {
+    if (this.disabled()) {
+      this.control.disable({ emitEvent: false });
+    } else {
+      this.control.enable({ emitEvent: false });
+    }
+  });
+}
+
+@Component({
+  selector: 'app-numeric-field-value-binding-story',
+  imports: [MatFormFieldModule, MatInputModule, NumericFieldDirective],
+  template: `
+    <div style="display: grid; gap: 1rem; max-width: 420px;">
+      <mat-form-field appearance="outline">
+        <mat-label>numericValue binding</mat-label>
+        <input
+          matInput
+          autocomplete="off"
+          [numericValue]="numericValue()"
+          (numericValueChange)="numericValue.set($event)"
+          [decimalPlaces]="2"
+          unit="kg"
+          unitPosition="right"
+          madNumericField
+        />
+      </mat-form-field>
+
+      <div style="font-size: 0.875rem;"><strong>numericValue:</strong> {{ numericValue() }}</div>
+    </div>
+  `,
+})
+class NumericFieldValueBindingStoryComponent {
+  readonly numericValue = signal(1234.56);
+}
+
+@Component({
+  selector: 'app-number-format-service-story',
+  template: `
+    <div style="display: grid; gap: 1rem;">
+      <table style="border-collapse: collapse; width: 100%;">
+        <thead>
+          <tr>
+            <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Locale</th>
+            <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Decimal</th>
+            <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Grouping</th>
+            <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Formatted</th>
+            <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Stripped input</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of rows(); track row.locale) {
+            <tr>
+              <td style="border: 1px solid #ccc; padding: 0.5rem;">
+                <code>{{ row.locale }}</code>
+              </td>
+              <td style="border: 1px solid #ccc; padding: 0.5rem;">
+                <code>{{ row.decimalSeparator }}</code>
+              </td>
+              <td style="border: 1px solid #ccc; padding: 0.5rem;">
+                <code>{{ row.groupingSeparator }}</code>
+              </td>
+              <td style="border: 1px solid #ccc; padding: 0.5rem;">
+                <code>{{ row.formatted }}</code>
+              </td>
+              <td style="border: 1px solid #ccc; padding: 0.5rem;">
+                <code>{{ row.stripped }}</code>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  `,
+})
+class NumberFormatServiceStoryComponent {
+  readonly value = input(1234567.89, { transform: numberAttribute });
+  readonly decimalPlaces = input(2, { transform: numberAttribute });
+  readonly autofillDecimals = input(false);
+
+  readonly rows = computed(() =>
+    ['de-DE', 'de-AT', 'en-EN'].map((locale) => {
+      const service = new NumberFormatService(locale);
+
+      return {
+        locale,
+        decimalSeparator: service.decimalSeparator,
+        groupingSeparator: service.groupingSeparator,
+        formatted: service.format(this.value(), {
+          decimalPlaces: this.decimalPlaces(),
+          autofillDecimals: this.autofillDecimals(),
+        }),
+        stripped: service.strip(locale === 'en-EN' ? '1,234,567.89' : '1.234.567,89', {
+          decimalPlaces: this.decimalPlaces(),
+        }),
+      };
+    }),
+  );
+}
+
+const meta: Meta<NumericFieldStoryArgs> = {
+  title: 'Components/Numeric Field',
+  decorators: [
+    moduleMetadata({
+      imports: [NumericFieldDirectiveStoryComponent, NumericFieldValueBindingStoryComponent, NumberFormatServiceStoryComponent],
+    }),
+  ],
+  parameters: {
+    layout: 'padded',
+    controls: {
+      expanded: true,
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    value: { control: 'number' },
+    decimalPlaces: { control: 'number' },
+    roundDisplayValue: { control: 'boolean' },
+    autofillDecimals: { control: 'boolean' },
+    unit: { control: 'text' },
+    unitPosition: {
+      control: { type: 'select' },
+      options: ['right', 'left'] satisfies UnitPosition[],
+    },
+    textAlign: {
+      control: { type: 'select' },
+      options: ['right', 'left'] satisfies UnitPosition[],
+    },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    label: 'Amount',
+    value: 1234.56,
+    decimalPlaces: 2,
+    roundDisplayValue: false,
+    autofillDecimals: false,
+    unit: 'EUR',
+    unitPosition: 'right',
+    textAlign: 'right',
+    disabled: false,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <app-numeric-field-directive-story
+        [label]="label"
+        [value]="value"
+        [decimalPlaces]="decimalPlaces"
+        [roundDisplayValue]="roundDisplayValue"
+        [autofillDecimals]="autofillDecimals"
+        [unit]="unit"
+        [unitPosition]="unitPosition"
+        [textAlign]="textAlign"
+        [disabled]="disabled"
+      />
+    `,
+  }),
+};
+
+export default meta;
+
+type Story = StoryObj<NumericFieldStoryArgs>;
+
+export const Playground: Story = {
+  args: {},
+};
+
+export const AutofillDecimals: Story = {
+  args: {
+    label: 'Money',
+    value: 1234.5,
+    autofillDecimals: true,
+    unit: 'EUR',
+  },
+};
+
+export const IntegerValue: Story = {
+  args: {
+    label: 'Mileage',
+    value: 123456,
+    decimalPlaces: 0,
+    unit: 'km',
+  },
+};
+
+export const LeftUnit: Story = {
+  args: {
+    label: 'Price',
+    value: 99.99,
+    unit: 'EUR',
+    unitPosition: 'left',
+    textAlign: 'left',
+    autofillDecimals: true,
+  },
+};
+
+export const RoundedDisplayValue: Story = {
+  args: {
+    label: 'Power',
+    value: 1234.567,
+    roundDisplayValue: true,
+    unit: 'kW',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const NumericValueBinding: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => ({
+    template: '<app-numeric-field-value-binding-story />',
+  }),
+};
+
+export const NumberFormatServiceFormatting: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => ({
+    template: '<app-number-format-service-story />',
+  }),
+};

--- a/src/stories/numeric-field.stories.ts
+++ b/src/stories/numeric-field.stories.ts
@@ -1,17 +1,21 @@
 import { JsonPipe } from '@angular/common';
-import { Component, computed, effect, input, numberAttribute, signal } from '@angular/core';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Component, LOCALE_ID, computed, effect, input, numberAttribute, signal } from '@angular/core';
+import { AbstractControl, FormControl, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import type { Meta, StoryObj } from '@storybook/angular';
-import { moduleMetadata } from '@storybook/angular';
+import { applicationConfig, moduleMetadata } from '@storybook/angular';
 import { NumberFormatService, NumericFieldDirective } from '@porscheinformatik/material-addons';
 
 type UnitPosition = 'right' | 'left';
+type NumericValue = number | null | undefined;
+
+const REQUIRED_VALIDATOR = (control: AbstractControl): ValidationErrors | null => Validators.required(control);
 
 interface NumericFieldStoryArgs {
   label: string;
-  value: number | null | undefined;
+  value: NumericValue;
   decimalPlaces: number;
   roundDisplayValue: boolean;
   autofillDecimals: boolean;
@@ -19,7 +23,63 @@ interface NumericFieldStoryArgs {
   unitPosition: UnitPosition;
   textAlign: UnitPosition;
   disabled: boolean;
+  readonly: boolean;
 }
+
+interface LocaleFormattingRow {
+  locale: string;
+  decimalSeparator: string;
+  decimalSeparatorCodePoint: string;
+  groupingSeparator: string;
+  groupingSeparatorCodePoint: string;
+  sampleInput: string;
+  formatted: string;
+  stripped: string;
+}
+
+const fixedStoryParameters = {
+  controls: { disable: true },
+};
+
+const formatCodePoint = (value: string): string =>
+  [...value].map((character) => `U+${character.codePointAt(0)?.toString(16).toUpperCase().padStart(4, '0')}`).join(' ');
+
+const formatSeparator = (separator: string): string => {
+  switch (separator) {
+    case ' ':
+      return 'space';
+    case '\u00A0':
+      return 'no-break space';
+    case '\u202F':
+      return 'narrow no-break space';
+    default:
+      return separator;
+  }
+};
+
+const localeDecorators = (locale: string) => [
+  applicationConfig({
+    providers: [{ provide: LOCALE_ID, useValue: locale }, NumberFormatService],
+  }),
+];
+
+const renderDirectiveStory = (args: NumericFieldStoryArgs) => ({
+  props: args,
+  template: `
+    <app-numeric-field-directive-story
+      [label]="label"
+      [value]="value"
+      [decimalPlaces]="decimalPlaces"
+      [roundDisplayValue]="roundDisplayValue"
+      [autofillDecimals]="autofillDecimals"
+      [unit]="unit"
+      [unitPosition]="unitPosition"
+      [textAlign]="textAlign"
+      [disabled]="disabled"
+      [readonly]="readonly"
+    />
+  `,
+});
 
 @Component({
   selector: 'app-numeric-field-directive-story',
@@ -30,8 +90,10 @@ interface NumericFieldStoryArgs {
         <mat-label>{{ label() }}</mat-label>
         <input
           matInput
+          type="text"
           autocomplete="off"
           [formControl]="control"
+          [readonly]="readonly()"
           [decimalPlaces]="decimalPlaces()"
           [roundDisplayValue]="roundDisplayValue()"
           [autofillDecimals]="autofillDecimals()"
@@ -45,13 +107,14 @@ interface NumericFieldStoryArgs {
       <div style="display: grid; gap: 0.25rem; font-size: 0.875rem;">
         <div><strong>Form value:</strong> {{ control.value | json }}</div>
         <div><strong>Disabled:</strong> {{ control.disabled }}</div>
+        <div><strong>Readonly:</strong> {{ readonly() }}</div>
       </div>
     </div>
   `,
 })
 class NumericFieldDirectiveStoryComponent {
   readonly label = input('Amount');
-  readonly value = input<number | null | undefined>(1234.56);
+  readonly value = input<NumericValue>(1234.56);
   readonly decimalPlaces = input(2, { transform: numberAttribute });
   readonly roundDisplayValue = input(false);
   readonly autofillDecimals = input(false);
@@ -59,8 +122,9 @@ class NumericFieldDirectiveStoryComponent {
   readonly unitPosition = input<UnitPosition>('right');
   readonly textAlign = input<UnitPosition>('right');
   readonly disabled = input(false);
+  readonly readonly = input(false);
 
-  readonly control = new FormControl<number | null | undefined>(1234.56);
+  readonly control = new FormControl<NumericValue>(1234.56);
 
   private readonly valueEffect = effect(() => {
     const value = this.value();
@@ -80,14 +144,90 @@ class NumericFieldDirectiveStoryComponent {
 }
 
 @Component({
+  selector: 'app-numeric-field-reset-story',
+  imports: [JsonPipe, MatButtonModule, MatFormFieldModule, MatInputModule, NumericFieldDirective, ReactiveFormsModule],
+  template: `
+    <div style="display: grid; gap: 1rem; max-width: 420px;">
+      <mat-form-field appearance="outline">
+        <mat-label>Resettable amount</mat-label>
+        <input matInput type="text" autocomplete="off" [formControl]="control" unit="EUR" madNumericField />
+      </mat-form-field>
+
+      <div style="display: flex; gap: 0.5rem;">
+        <button mat-stroked-button type="button" (click)="reset()">Reset</button>
+        <button mat-stroked-button type="button" (click)="restore()">Restore value</button>
+      </div>
+
+      <div style="font-size: 0.875rem;"><strong>Form value:</strong> {{ control.value | json }}</div>
+    </div>
+  `,
+})
+class NumericFieldResetStoryComponent {
+  readonly control = new FormControl<NumericValue>(1234.56);
+
+  reset(): void {
+    this.control.reset();
+  }
+
+  restore(): void {
+    this.control.setValue(1234.56);
+  }
+}
+
+@Component({
+  selector: 'app-numeric-field-validation-story',
+  imports: [JsonPipe, MatFormFieldModule, MatInputModule, NumericFieldDirective, ReactiveFormsModule],
+  template: `
+    <div style="display: grid; gap: 1rem; max-width: 420px;">
+      <mat-form-field appearance="outline">
+        <mat-label>Percentage</mat-label>
+        <input matInput type="text" autocomplete="off" [formControl]="control" [decimalPlaces]="0" unit="%" madNumericField />
+        @if (control.invalid) {
+          <mat-error>{{ errorMessage() }}</mat-error>
+        }
+      </mat-form-field>
+
+      <div style="font-size: 0.875rem;"><strong>Form value:</strong> {{ control.value | json }}</div>
+    </div>
+  `,
+})
+class NumericFieldValidationStoryComponent {
+  readonly control = new FormControl<NumericValue>(120, {
+    validators: [REQUIRED_VALIDATOR, Validators.min(0), Validators.max(100)],
+    updateOn: 'blur',
+  });
+
+  constructor() {
+    this.control.markAsTouched();
+  }
+
+  errorMessage(): string {
+    if (this.control.hasError('required')) {
+      return 'A percentage is required';
+    }
+
+    if (this.control.hasError('min')) {
+      return 'Enter a value greater than or equal to 0';
+    }
+
+    if (this.control.hasError('max')) {
+      return 'Enter a value less than or equal to 100';
+    }
+
+    return '';
+  }
+}
+
+@Component({
   selector: 'app-numeric-field-value-binding-story',
-  imports: [MatFormFieldModule, MatInputModule, NumericFieldDirective],
+  imports: [JsonPipe, MatButtonModule, MatFormFieldModule, MatInputModule, NumericFieldDirective],
   template: `
     <div style="display: grid; gap: 1rem; max-width: 420px;">
       <mat-form-field appearance="outline">
         <mat-label>numericValue binding</mat-label>
         <input
           matInput
+          type="text"
           autocomplete="off"
           [numericValue]="numericValue()"
           (numericValueChange)="numericValue.set($event)"
@@ -98,12 +238,30 @@ class NumericFieldDirectiveStoryComponent {
         />
       </mat-form-field>
 
-      <div style="font-size: 0.875rem;"><strong>numericValue:</strong> {{ numericValue() }}</div>
+      <div style="display: flex; gap: 0.5rem;">
+        <button mat-stroked-button type="button" (click)="setValue()">Set value</button>
+        <button mat-stroked-button type="button" (click)="clearValue()">Clear value</button>
+      </div>
+
+      <div style="font-size: 0.875rem;"><strong>numericValue:</strong> {{ numericValue() | json }}</div>
     </div>
   `,
 })
 class NumericFieldValueBindingStoryComponent {
-  readonly numericValue = signal(1234.56);
+  readonly initialValue = input<NumericValue>(1234.56);
+  readonly numericValue = signal<NumericValue>(1234.56);
+
+  private readonly initialValueEffect = effect(() => {
+    this.numericValue.set(this.initialValue());
+  });
+
+  setValue(): void {
+    this.numericValue.set(1234.56);
+  }
+
+  clearValue(): void {
+    this.numericValue.set(undefined);
+  }
 }
 
 @Component({
@@ -116,6 +274,7 @@ class NumericFieldValueBindingStoryComponent {
             <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Locale</th>
             <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Decimal</th>
             <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Grouping</th>
+            <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Sample input</th>
             <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Formatted</th>
             <th style="border: 1px solid #ccc; padding: 0.5rem; text-align: left;">Stripped input</th>
           </tr>
@@ -128,9 +287,14 @@ class NumericFieldValueBindingStoryComponent {
               </td>
               <td style="border: 1px solid #ccc; padding: 0.5rem;">
                 <code>{{ row.decimalSeparator }}</code>
+                <div style="font-size: 0.75rem;">{{ row.decimalSeparatorCodePoint }}</div>
               </td>
               <td style="border: 1px solid #ccc; padding: 0.5rem;">
                 <code>{{ row.groupingSeparator }}</code>
+                <div style="font-size: 0.75rem;">{{ row.groupingSeparatorCodePoint }}</div>
+              </td>
+              <td style="border: 1px solid #ccc; padding: 0.5rem;">
+                <code>{{ row.sampleInput }}</code>
               </td>
               <td style="border: 1px solid #ccc; padding: 0.5rem;">
                 <code>{{ row.formatted }}</code>
@@ -150,19 +314,23 @@ class NumberFormatServiceStoryComponent {
   readonly decimalPlaces = input(2, { transform: numberAttribute });
   readonly autofillDecimals = input(false);
 
-  readonly rows = computed(() =>
-    ['de-DE', 'de-AT', 'en-EN'].map((locale) => {
+  readonly rows = computed<LocaleFormattingRow[]>(() =>
+    ['en-US', 'en-EN', 'de-DE', 'de-AT', 'fr-FR'].map((locale) => {
       const service = new NumberFormatService(locale);
+      const sampleInput = `1${service.groupingSeparator}234${service.groupingSeparator}567${service.decimalSeparator}89`;
 
       return {
         locale,
-        decimalSeparator: service.decimalSeparator,
-        groupingSeparator: service.groupingSeparator,
+        decimalSeparator: formatSeparator(service.decimalSeparator),
+        decimalSeparatorCodePoint: formatCodePoint(service.decimalSeparator),
+        groupingSeparator: formatSeparator(service.groupingSeparator),
+        groupingSeparatorCodePoint: formatCodePoint(service.groupingSeparator),
+        sampleInput,
         formatted: service.format(this.value(), {
           decimalPlaces: this.decimalPlaces(),
           autofillDecimals: this.autofillDecimals(),
         }),
-        stripped: service.strip(locale === 'en-EN' ? '1,234,567.89' : '1.234.567,89', {
+        stripped: service.strip(sampleInput, {
           decimalPlaces: this.decimalPlaces(),
         }),
       };
@@ -174,7 +342,13 @@ const meta: Meta<NumericFieldStoryArgs> = {
   title: 'Components/Numeric Field',
   decorators: [
     moduleMetadata({
-      imports: [NumericFieldDirectiveStoryComponent, NumericFieldValueBindingStoryComponent, NumberFormatServiceStoryComponent],
+      imports: [
+        NumericFieldDirectiveStoryComponent,
+        NumericFieldResetStoryComponent,
+        NumericFieldValidationStoryComponent,
+        NumericFieldValueBindingStoryComponent,
+        NumberFormatServiceStoryComponent,
+      ],
     }),
   ],
   parameters: {
@@ -200,6 +374,7 @@ const meta: Meta<NumericFieldStoryArgs> = {
       options: ['right', 'left'] satisfies UnitPosition[],
     },
     disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
   },
   args: {
     label: 'Amount',
@@ -211,23 +386,9 @@ const meta: Meta<NumericFieldStoryArgs> = {
     unitPosition: 'right',
     textAlign: 'right',
     disabled: false,
+    readonly: false,
   },
-  render: (args) => ({
-    props: args,
-    template: `
-      <app-numeric-field-directive-story
-        [label]="label"
-        [value]="value"
-        [decimalPlaces]="decimalPlaces"
-        [roundDisplayValue]="roundDisplayValue"
-        [autofillDecimals]="autofillDecimals"
-        [unit]="unit"
-        [unitPosition]="unitPosition"
-        [textAlign]="textAlign"
-        [disabled]="disabled"
-      />
-    `,
-  }),
+  render: renderDirectiveStory,
 };
 
 export default meta;
@@ -238,6 +399,49 @@ export const Playground: Story = {
   args: {},
 };
 
+export const ReactiveFormInitialValue: Story = {
+  args: {
+    label: 'Initial amount',
+    value: 1234.56,
+    unit: 'EUR',
+  },
+  parameters: fixedStoryParameters,
+};
+
+export const ReactiveFormDisabled: Story = {
+  args: {
+    label: 'Disabled amount',
+    value: 1234.56,
+    disabled: true,
+    unit: 'EUR',
+  },
+  parameters: fixedStoryParameters,
+};
+
+export const ReactiveFormReset: Story = {
+  parameters: fixedStoryParameters,
+  render: () => ({
+    template: '<app-numeric-field-reset-story />',
+  }),
+};
+
+export const Validation: Story = {
+  parameters: fixedStoryParameters,
+  render: () => ({
+    template: '<app-numeric-field-validation-story />',
+  }),
+};
+
+export const ReadonlyNativeInput: Story = {
+  args: {
+    label: 'Readonly amount',
+    value: 1234.56,
+    readonly: true,
+    unit: 'EUR',
+  },
+  parameters: fixedStoryParameters,
+};
+
 export const AutofillDecimals: Story = {
   args: {
     label: 'Money',
@@ -245,6 +449,7 @@ export const AutofillDecimals: Story = {
     autofillDecimals: true,
     unit: 'EUR',
   },
+  parameters: fixedStoryParameters,
 };
 
 export const IntegerValue: Story = {
@@ -254,6 +459,46 @@ export const IntegerValue: Story = {
     decimalPlaces: 0,
     unit: 'km',
   },
+  parameters: fixedStoryParameters,
+};
+
+export const PrecisionValue: Story = {
+  args: {
+    label: 'Length',
+    value: 12.3456,
+    decimalPlaces: 4,
+    unit: 'mm',
+  },
+  parameters: fixedStoryParameters,
+};
+
+export const RoundedDisplayValue: Story = {
+  args: {
+    label: 'Power',
+    value: 1234.567,
+    roundDisplayValue: true,
+    unit: 'kW',
+  },
+  parameters: fixedStoryParameters,
+};
+
+export const NegativeValue: Story = {
+  args: {
+    label: 'Balance',
+    value: -1234.56,
+    unit: 'EUR',
+  },
+  parameters: fixedStoryParameters,
+};
+
+export const RightUnit: Story = {
+  args: {
+    label: 'Weight',
+    value: 1540,
+    unit: 'kg',
+    unitPosition: 'right',
+  },
+  parameters: fixedStoryParameters,
 };
 
 export const LeftUnit: Story = {
@@ -265,37 +510,76 @@ export const LeftUnit: Story = {
     textAlign: 'left',
     autofillDecimals: true,
   },
+  parameters: fixedStoryParameters,
 };
 
-export const RoundedDisplayValue: Story = {
+export const LeftAlignedRightUnit: Story = {
   args: {
-    label: 'Power',
-    value: 1234.567,
-    roundDisplayValue: true,
-    unit: 'kW',
+    label: 'Measured value',
+    value: 1540,
+    unit: 'kg',
+    unitPosition: 'right',
+    textAlign: 'left',
   },
+  parameters: fixedStoryParameters,
 };
 
-export const Disabled: Story = {
+export const NoUnit: Story = {
   args: {
-    disabled: true,
+    label: 'Plain value',
+    value: 1234.56,
+    unit: null,
   },
+  parameters: fixedStoryParameters,
+};
+
+export const EnglishLocale: Story = {
+  args: {
+    label: 'English locale',
+    value: 1234.56,
+    unit: 'EUR',
+  },
+  decorators: localeDecorators('en-US'),
+  parameters: fixedStoryParameters,
+};
+
+export const GermanLocale: Story = {
+  args: {
+    label: 'German locale',
+    value: 1234.56,
+    unit: 'EUR',
+  },
+  decorators: localeDecorators('de-DE'),
+  parameters: fixedStoryParameters,
+};
+
+export const FrenchLocale: Story = {
+  args: {
+    label: 'French locale',
+    value: 1234.56,
+    unit: 'EUR',
+  },
+  decorators: localeDecorators('fr-FR'),
+  parameters: fixedStoryParameters,
+};
+
+export const LocaleFormattingTable: Story = {
+  parameters: fixedStoryParameters,
+  render: () => ({
+    template: '<app-number-format-service-story />',
+  }),
 };
 
 export const NumericValueBinding: Story = {
-  parameters: {
-    controls: { disable: true },
-  },
+  parameters: fixedStoryParameters,
   render: () => ({
     template: '<app-numeric-field-value-binding-story />',
   }),
 };
 
-export const NumberFormatServiceFormatting: Story = {
-  parameters: {
-    controls: { disable: true },
-  },
+export const NumericValueCleared: Story = {
+  parameters: fixedStoryParameters,
   render: () => ({
-    template: '<app-number-format-service-story />',
+    template: '<app-numeric-field-value-binding-story [initialValue]="undefined" />',
   }),
 };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,6 @@
     "types": []
   },
   "files": ["src/main.ts", "src/polyfills.ts"],
-  "include": ["src/**/*.d.ts"],
+  "include": ["src/**/*.d.ts", "src/environments/**/*.ts"],
   "exclude": ["src/test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
### Description

Refactored NumericFieldDirective and NumberFormatService:
- Directive refactored to use up-to-date signals (no API change for consumers)
- Unit tests are recreated for both
- Stories are created for directive
- Fix issue with label overflow for CVA usage of directive (had setTimeout for update value which was not notified Material Input)
- Switched keyUp and keyDown listeners to more Angular-native approach 

### Which Component is affected or generated?

- numeric-field.directive
- number-format.service

### Known issues which are going to be fixed later

- With unitPosition='left', textAlign='left' and unit exists - label oveflow unit if input does not contain any value (spans which are injected into input by directive itself - is not really a matSuffix/matPrefix)
- With disabled state - injected unit is not in gray color (like disable control itself)

For known issues there will be another refactoring rounds