### PR TITLE
Form field label size change

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ For migration from M2 (v21.x) to M3 (v22.x), see [MIGRATION_M2_TO_M3.md](MIGRATI
 _Hint: Changes marked as **visible change** directly affect your application during version upgrade. **Breaking**
 requires your attention during upgrade._
 
-- **22.1.3**: Change data-table row border bottom color to previous version. Introduced new css variable --datatable-row-border-color
-- **22.1.2**: Fix madNumericField directive lifecycle loop
-- **22.1.1**: Fix handling of disabled button click event
-- **22.1.0**: Refactored data-table components, demo page, tests and added stories
+- **22.2.0**: Introduced --mad-form-field-outlined-floating-label-scale CSS custom token for configuring the outlined form-field floating-label scale. The default value is 0.875
+- **22.1.3**: Change data-table row border bottom color to previous version. Introduced new css variable --datatable-row-border-color.
+- **22.1.2**: Fix madNumericField directive lifecycle loop.
+- **22.1.1**: Fix handling of disabled button click event.
+- **22.1.0**: Refactored data-table components, demo page, tests and added stories.
 - **22.0.12**: Change data-table-filter-dialog approach to cdk overlay.
 - **22.0.11**: Storybook for demo application is published to gh-pages. Release workflow updated.
 - **22.0.10**: Fixed card-action buttons alignment. Refactoring of the button components. Update button documentation.

--- a/projects/material-addons/README.md
+++ b/projects/material-addons/README.md
@@ -51,6 +51,18 @@ Material addons requires an already set-up Angular Material project. To do a fre
 
 Material Addons exposes CSS variables for customization:
 
+| Variable | Default | Description |
+| --- | --- | --- |
+| `--mad-form-field-outlined-floating-label-scale` | `0.875` | Controls the scale of floating labels in outlined form fields. Use `0.75` for the Angular Material default or `1` to keep the floating label at full size. |
+
+For example, restore the Angular Material floating-label scale globally:
+
+```scss
+:root {
+  --mad-form-field-outlined-floating-label-scale: 0.75;
+}
+```
+
 ```scss
 // Existing variables (v21.x and earlier)
 --main-primary, --selection-background, --hover-color

--- a/projects/material-addons/src/themes/common/components/_material-overrides.scss
+++ b/projects/material-addons/src/themes/common/components/_material-overrides.scss
@@ -42,5 +42,7 @@
     --mdc-outlined-text-field-outline-color: var(--mat-sys-outline);
     --mdc-outlined-text-field-focus-outline-color: var(--main-primary);
     --mdc-outlined-text-field-hover-outline-color: var(--mat-sys-on-surface);
+    --mat-mdc-form-field-floating-label-scale: 1;
+    --mat-form-field-outlined-label-text-populated-size: 14px;
   }
 }

--- a/projects/material-addons/src/themes/common/components/_material-overrides.scss
+++ b/projects/material-addons/src/themes/common/components/_material-overrides.scss
@@ -42,7 +42,6 @@
     --mdc-outlined-text-field-outline-color: var(--mat-sys-outline);
     --mdc-outlined-text-field-focus-outline-color: var(--main-primary);
     --mdc-outlined-text-field-hover-outline-color: var(--mat-sys-on-surface);
-    --mat-mdc-form-field-floating-label-scale: 1;
-    --mat-form-field-outlined-label-text-populated-size: 14px;
+    --mat-mdc-form-field-floating-label-scale: var(--mad-form-field-outlined-floating-label-scale, 0.875);
   }
 }

--- a/projects/material-addons/src/version.ts
+++ b/projects/material-addons/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '22.1.3';
+export const VERSION = '22.2.0';


### PR DESCRIPTION
### Description

Increasing label size of outlined form fields. 

### Which Component is affected or generated?
All mat-form-field instances will display new scale. 
But also was introduced new scss variable **--mad-form-field-outlined-floating-label-scale** for consumers to be able to overwrite scale of label if needed (Angular material defalt is 0.75)
