### PR TITLE
data table row border bottom color changed

### DIFF
--- a/projects/material-addons/src/lib/data-table/data-table.component.scss
+++ b/projects/material-addons/src/lib/data-table/data-table.component.scss
@@ -36,6 +36,8 @@
 
 .datatable {
   table {
+    --mat-table-row-item-outline-color: var(--datatable-row-border-color, #0000001f);
+
     width: 100%;
     max-height: 100%;
 

--- a/projects/material-addons/src/themes/common/tokens/_tokens.scss
+++ b/projects/material-addons/src/themes/common/tokens/_tokens.scss
@@ -100,6 +100,7 @@ $default-palette: (
   --toolbar-background: var(--mat-sys-surface);
   --datatable-background: var(--mat-sys-surface);
   --datatable-hover: var(--mat-sys-surface-variant);
+  --datatable-row-border-color: #0000001f;
   --container-shape: 0.25rem;
   --breadcrumb-separator-color: #{$breadcrumb-separator-color};
 }

--- a/src/app/component-demos/color-palette-demo/color-palette-demo.component.ts
+++ b/src/app/component-demos/color-palette-demo/color-palette-demo.component.ts
@@ -111,6 +111,7 @@ export class ColorsDemoComponent {
     { label: 'Toolbar Background', variable: '--toolbar-background' },
     { label: 'Datatable Background', variable: '--datatable-background' },
     { label: 'Datatable Hover', variable: '--datatable-hover' },
+    { label: 'Datatable Row Border', variable: '--datatable-row-border-color' },
     { label: 'Step Header Selected', variable: '--step-header-selected-background' },
     { label: 'Step Header Default', variable: '--step-header-default-background' },
     { label: 'Step Border', variable: '--step-border-color' },

--- a/src/app/component-demos/data-table-demo/data-table-demo-api-spec/data-table-demo-api-spec.component.ts
+++ b/src/app/component-demos/data-table-demo/data-table-demo-api-spec/data-table-demo-api-spec.component.ts
@@ -418,5 +418,9 @@ export class DataTableDemoApiSpecComponent {
       property: '--datatable-hover',
       description: 'Active column definition background color',
     },
+    {
+      property: '--datatable-row-border-color',
+      description: 'Header and body row separator color',
+    },
   ];
 }


### PR DESCRIPTION
### Description

Adds the public --datatable-row-border-color CSS custom property with a default value of #0000001f
Data table maps this property internally to Angular Material's table outline token, allowing consumers to customize row separator colors without depending on Angular Material implementation details.
Property is documented in the API specification and color pallete demo

### Which Component is affected or generated?

- mad-data-table
